### PR TITLE
Support Ecto 2.1, by using utc_datetime as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ The library source code is minimal and tested. It is highly suggested that you c
   4. run this command to generate the migration:
 
   ```mix papertrail.install```
+  
+  5. If you do not wish to use `:utc_datetime` for storing your timestamps, change the migration to `:naive_datetime`.
+     This was changed in Ecto 2.1, see the [CHANGELOG.md](https://github.com/elixir-ecto/ecto/blob/v2.1/CHANGELOG.md) for
+     more details.
 
   5. run the migration:
 

--- a/lib/mix/tasks/papertrail/install.ex
+++ b/lib/mix/tasks/papertrail/install.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Papertrail.Install do
           add :item_changes, :map
           add :meta,         :map
 
-          add :inserted_at,  :datetime, null: false
+          add :inserted_at,  :utc_datetime, null: false
         end
 
         # Uncomment if you want to add the following indexes to speed up special queries:


### PR DESCRIPTION
Let me know if you want to use `:naive_datetime` or something as default.