### PR TITLE
fix test warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule PaperTrail.Mixfile do
       description: description(),
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
+      elixirc_paths: elixirc_paths(Mix.env),
       package: package(),
       deps: deps()
     ]
@@ -50,4 +51,6 @@ defmodule PaperTrail.Mixfile do
       }
     ]
   end
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -1,0 +1,22 @@
+defmodule PaperTrail.Repo do
+  use Ecto.Repo, otp_app: :paper_trail
+end
+
+defmodule User do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "users" do
+    field :token, :string
+    field :username, :string
+
+    timestamps()
+  end
+
+  def changeset(model, params \\ %{}) do
+    model
+    |> cast(params, [:token, :username])
+    |> validate_required([:token, :username])
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,28 +1,5 @@
 # TODO: strict_mode(check the current_version_id changes on next versions), Test error cases, producer_id, PaperTrail.insert_all
 
-defmodule PaperTrail.Repo do
-  use Ecto.Repo, otp_app: :paper_trail
-end
-
-defmodule User do
-  use Ecto.Schema
-
-  import Ecto.Changeset
-
-  schema "users" do
-    field :token, :string
-    field :username, :string
-
-    timestamps()
-  end
-
-  def changeset(model, params \\ %{}) do
-    model
-    |> cast(params, [:token, :username])
-    |> validate_required([:token, :username])
-  end
-end
-
 Mix.Task.run "ecto.create", ~w(-r PaperTrail.Repo)
 Mix.Task.run "ecto.migrate", ~w(-r PaperTrail.Repo)
 


### PR DESCRIPTION
The warnings were from referencing a module that doesn't exist at compile-time.  Changing it so the referenced module is compiled fixes the errors.