### PR TITLE
Drop association changes on update

### DIFF
--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -275,7 +275,7 @@ defmodule PaperTrail do
       event: "update",
       item_type: changeset.data.__struct__ |> Module.split |> List.last,
       item_id: changeset.data.id,
-      item_changes: changeset.changes,
+      item_changes: serialize_changes(changeset),
       originator_id: case originator_ref do
         nil -> nil
         _ -> originator_ref |> Map.get(:id)
@@ -317,5 +317,10 @@ defmodule PaperTrail do
   defp serialize(model) do
     relationships = model.__struct__.__schema__(:associations)
     Map.drop(model, [:__struct__, :__meta__] ++ relationships)
+  end
+
+  defp serialize_changes(changeset) do
+    relationships = changeset.data.__struct__.__schema__(:associations)
+    Map.drop(changeset.changes, relationships)
   end
 end

--- a/test/paper_trail_test.exs
+++ b/test/paper_trail_test.exs
@@ -10,6 +10,7 @@ defmodule PaperTrailTest do
   @repo PaperTrail.RepoClient.repo
   @create_company_params %{name: "Acme LLC", is_active: true, city: "Greenwich"}
   @update_company_params %{city: "Hong Kong", website: "http://www.acme.com", facebook: "acme.llc"}
+  @create_company_with_people_params %{name: "Acme LLC", is_active: true, city: "Greenwich", people: [%{first_name: "Izel"}]}
 
   doctest PaperTrail
 
@@ -323,6 +324,46 @@ defmodule PaperTrailTest do
     assert person == first(Person, :id) |> @repo.one |> serialize
   end
 
+  test "updating a company with people changes creates a version with correct attributes" do
+    {:ok, %{model: company}} = create_company_with_people_with_version()
+    {:ok, result} = Company.people_changeset(company, %{
+      name: "Another Company",
+      people: [%{id: List.first(company.people).id, first_name: "Itsquall"}]
+    }) |> PaperTrail.update
+
+    company_count = Person.count()
+    version_count = Version.count()
+
+    company = result[:model] |> serialize
+    version = result[:version] |> serialize
+
+    assert Map.keys(result) == [:model, :version]
+    assert company_count == 1
+    assert version_count == 2
+    assert Map.drop(company, [:id, :inserted_at, :updated_at]) == %{
+      name: "Another Company",
+      address: nil,
+      city: "Greenwich",
+      twitter: nil,
+      facebook: nil,
+      founded_in: nil,
+      is_active: true,
+      website: nil
+    }
+    assert Map.drop(version, [:id, :inserted_at]) == %{
+      event: "update",
+      item_type: "SimpleCompany",
+      item_id: company.id,
+      item_changes: %{
+        name: "Another Company",
+      },
+      originator_id: nil,
+      origin: nil,
+      meta: nil
+    }
+    assert company == first(Company, :id) |> @repo.one |> serialize
+  end
+
   test "deleting a person creates a person version with correct attributes" do
     create_company_with_version(%{name: "Acme LLC", website: "http://www.acme.com"})
     {:ok, target_company_insertion} = create_company_with_version(%{
@@ -386,6 +427,10 @@ defmodule PaperTrailTest do
 
   defp update_company_with_version(company, params \\ @update_company_params, options \\ nil) do
     Company.changeset(company, params) |> PaperTrail.update(options)
+  end
+
+  defp create_company_with_people_with_version(params \\ @create_company_with_people_params, options \\ nil) do
+    Company.people_changeset(%Company{}, params) |> PaperTrail.insert(options)
   end
 
   defp serialize(model) do

--- a/test/support/simple_models.exs
+++ b/test/support/simple_models.exs
@@ -28,6 +28,13 @@ defmodule SimpleCompany do
     |> no_assoc_constraint(:people)
   end
 
+  def people_changeset(model, params \\ %{}) do
+    model
+    |> cast(params, @optional_fields)
+    |> cast_assoc(:people)
+    |> validate_required([:name])
+  end
+
   def count do
     from(record in __MODULE__, select: count(record.id)) |> PaperTrail.RepoClient.repo.one
   end


### PR DESCRIPTION
Related to #17

## PR purpose
As I explained on the associated issue, there was a problem with changesets including changes in their associations.

So, in the same way, you drop associations on `serialize(model)`, you need to drop it from changes map.

Please, take a look and let me know if you want I change something here.