### PR TITLE
Replace use of module attribute to reference repo, originator, and re…

### DIFF
--- a/lib/version.ex
+++ b/lib/version.ex
@@ -4,26 +4,22 @@ defmodule PaperTrail.Version do
   import Ecto.Changeset
   import Ecto.Query
 
-  @setter PaperTrail.RepoClient.originator || nil
-
+  # @setter PaperTrail.RepoClient.originator()
   # @item_type Application.get_env(:paper_trail, :item_type, :integer)
   # @originator_type Application.get_env(:paper_trail, :originator_type, :integer)
 
   schema "versions" do
-    item_type = Application.get_env(:paper_trail, :item_type, :integer)
-    originator_type = Application.get_env(:paper_trail, :originator_type, :integer)
-
 
     field :event, :string
     field :item_type, :string
-    field :item_id, item_type
+    field :item_id, Application.get_env(:paper_trail, :item_type, :integer)
     field :item_changes, :map
-    field :originator_id, originator_type
+    field :originator_id, Application.get_env(:paper_trail, :originator_type, :integer)
     field :origin, :string, read_after_writes: true
     field :meta, :map
 
-    if @setter do
-      belongs_to @setter[:name], @setter[:model], define_field: false, foreign_key: :originator_id, type: originator_type
+    if PaperTrail.RepoClient.originator() do
+      belongs_to PaperTrail.RepoClient.originator()[:name], PaperTrail.RepoClient.originator()[:model], define_field: false, foreign_key: :originator_id, type: Application.get_env(:paper_trail, :originator_type, :integer)
     end
 
     timestamps(updated_at: false)
@@ -39,7 +35,7 @@ defmodule PaperTrail.Version do
   Returns the count of all version records in the database
   """
   def count do
-    from(version in __MODULE__, select: count(version.id)) |> PaperTrail.RepoClient.repo.one
+    from(version in __MODULE__, select: count(version.id)) |> PaperTrail.RepoClient.repo.one()
   end
   def count(options) do
     from(version in __MODULE__, select: count(version.id))

--- a/lib/version.ex
+++ b/lib/version.ex
@@ -6,20 +6,24 @@ defmodule PaperTrail.Version do
 
   @setter PaperTrail.RepoClient.originator || nil
 
-  @item_type Application.get_env(:paper_trail, :item_type, :integer)
-  @originator_type Application.get_env(:paper_trail, :originator_type, :integer)
+  # @item_type Application.get_env(:paper_trail, :item_type, :integer)
+  # @originator_type Application.get_env(:paper_trail, :originator_type, :integer)
 
   schema "versions" do
+    item_type = Application.get_env(:paper_trail, :item_type, :integer)
+    originator_type = Application.get_env(:paper_trail, :originator_type, :integer)
+
+
     field :event, :string
     field :item_type, :string
-    field :item_id, @item_type
+    field :item_id, item_type
     field :item_changes, :map
-    field :originator_id, @originator_type
+    field :originator_id, originator_type
     field :origin, :string, read_after_writes: true
     field :meta, :map
 
     if @setter do
-      belongs_to @setter[:name], @setter[:model], define_field: false, foreign_key: :originator_id, type: @originator_type
+      belongs_to @setter[:name], @setter[:model], define_field: false, foreign_key: :originator_id, type: originator_type
     end
 
     timestamps(updated_at: false)


### PR DESCRIPTION
Hi @izelnakri, see https://github.com/izelnakri/paper_trail/issues/28

Replace use of module attribute to reference repo, originator, and repo_client, was causing problem not getting the correct config value.