### PR TITLE
warning: clauses for the same def should be grouped together

### DIFF
--- a/lib/paper_trail/version_queries.ex
+++ b/lib/paper_trail/version_queries.ex
@@ -59,22 +59,6 @@ defmodule PaperTrail.VersionQueries do
   def get_version(model, id) when is_atom(model) and is_integer(id), do: get_version(model, id, [])
 
   @doc """
-  Gets the last version of a record given its module reference and its id.
-
-  A list of options is optional, so you can set for example the :prefix of the query,
-  wich allows you to change between different tenants.
-
-  # Usage example:
-
-    iex(1)> PaperTrail.VersionQueries.get_version(ModelName, id, [prefix: "tenant_id"])
-  """
-  @spec get_version(model :: module, id :: pos_integer, options :: []) :: Ecto.Query.t
-  def get_version(model, id, options) do
-    item_type = model |> Module.split |> List.last
-    last(version_query(item_type, id, options)) |> @repo.one
-  end
-
-  @doc """
   Gets the last version of a record.
 
   A list of options is optional, so you can set for example the :prefix of the query,
@@ -88,6 +72,22 @@ defmodule PaperTrail.VersionQueries do
   def get_version(record, options) when is_map(record) do
     item_type = record.__struct__ |> Module.split |> List.last
     last(version_query(item_type, record.id, options)) |> @repo.one
+  end
+
+  @doc """
+  Gets the last version of a record given its module reference and its id.
+
+  A list of options is optional, so you can set for example the :prefix of the query,
+  wich allows you to change between different tenants.
+
+  # Usage example:
+
+    iex(1)> PaperTrail.VersionQueries.get_version(ModelName, id, [prefix: "tenant_id"])
+  """
+  @spec get_version(model :: module, id :: pos_integer, options :: []) :: Ecto.Query.t
+  def get_version(model, id, options) do
+    item_type = model |> Module.split |> List.last
+    last(version_query(item_type, id, options)) |> @repo.one
   end
 
   @doc """


### PR DESCRIPTION
Rearranged functions to avoid this warning:

```
warning: clauses for the same def should be grouped together, def get_version/2 was previously defined (lib/paper_trail/version_queries.ex:61)
  lib/paper_trail/version_queries.ex:90
```