### PR TITLE
get model id simply, and type check

### DIFF
--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -357,6 +357,13 @@ defmodule PaperTrail do
   defp add_prefix(changeset, prefix), do: Ecto.put_meta(changeset, prefix: prefix)
 
   def get_model_id(model) do
-    Map.get(model, List.first(model.__struct__.__schema__(:primary_key)))
+    {_, model_id} = List.first(Ecto.primary_key(model))
+
+    case PaperTrail.Version.__schema__(:type, :item_id) do
+      :integer ->
+        model_id
+      _ ->
+        "#{model_id}"
+    end
   end
 end

--- a/priv/uuid_repo/migrations/20170525133833_create_uuid_products.exs
+++ b/priv/uuid_repo/migrations/20170525133833_create_uuid_products.exs
@@ -8,12 +8,5 @@ defmodule PaperTrail.UUIDRepo.Migrations.CreateUuidProducts do
 
       timestamps()
     end
-
-    create table(:items, primary_key: false) do
-      add :item_id, :binary_id, primary_key: true
-      add :title, :string, null: false
-
-      timestamps()
-    end
   end
 end

--- a/priv/uuid_repo/migrations/20170525142612_create_versions.exs
+++ b/priv/uuid_repo/migrations/20170525142612_create_versions.exs
@@ -5,7 +5,7 @@ defmodule PaperTrail.UUIDRepo.Migrations.CreateVersions do
     create table(:versions) do
       add :event,        :string, null: false, size: 10
       add :item_type,    :string, null: false
-      add :item_id,      (if System.get_env("STR") == nil, do: :binary_id, else: :string)
+      add :item_id,      (if System.get_env("STRING_TEST") == nil, do: :binary_id, else: :string)
       add :item_changes, :map, null: false
       add :originator_id, references(:admins, type: :binary_id)
       add :origin,       :string, size: 50

--- a/priv/uuid_repo/migrations/20170525142612_create_versions.exs
+++ b/priv/uuid_repo/migrations/20170525142612_create_versions.exs
@@ -5,7 +5,7 @@ defmodule PaperTrail.UUIDRepo.Migrations.CreateVersions do
     create table(:versions) do
       add :event,        :string, null: false, size: 10
       add :item_type,    :string, null: false
-      add :item_id,      :binary_id
+      add :item_id,      (if System.get_env("STR") == nil, do: :binary_id, else: :string)
       add :item_changes, :map, null: false
       add :originator_id, references(:admins, type: :binary_id)
       add :origin,       :string, size: 50

--- a/priv/uuid_repo/migrations/20170525142613_create_items.exs
+++ b/priv/uuid_repo/migrations/20170525142613_create_items.exs
@@ -6,8 +6,20 @@ defmodule PaperTrail.UUIDRepo.Migrations.CreateItems do
       add :item_id,      :binary_id, null: false, primary_key: true
       add :title,        :string, null: false
 
-      add :inserted_at,  :utc_datetime, null: false
-      add :updated_at,  :utc_datetime, null: false
+      timestamps()
+    end
+
+    create table(:foo_items) do
+      add :title, :string, null: false
+
+      timestamps()
+    end
+
+    create table(:bar_items, primary_key: false) do
+      add :item_id, :string, primary_key: true
+      add :title, :string, null: false
+
+      timestamps()
     end
   end
 end

--- a/test/paper_trail/uuid_test.exs
+++ b/test/paper_trail/uuid_test.exs
@@ -8,7 +8,7 @@ defmodule PaperTrailTest.UUIDTest do
     Application.put_env(:paper_trail, :repo, PaperTrail.UUIDRepo)
     Application.put_env(:paper_trail, :originator, name: :admin, model: Admin)
     Application.put_env(:paper_trail, :originator_type, Ecto.UUID)
-    Application.put_env(:paper_trail, :item_type, Ecto.UUID)
+    Application.put_env(:paper_trail, :item_type, (if System.get_env("STR") == nil, do: Ecto.UUID, else: :string))
     Code.eval_file("lib/paper_trail.ex")
     Code.eval_file("lib/version.ex")
     repo().delete_all(Version)
@@ -57,5 +57,29 @@ defmodule PaperTrailTest.UUIDTest do
 
     version = Version |> last |> repo().one
     assert version.item_id == item.item_id
+  end
+
+  test "versioning models that have a integer primary key" do
+    if PaperTrail.Version.__schema__(:type, :item_id) == :string do
+      item =
+        %FooItem{}
+        |> FooItem.changeset(%{title: "hello"})
+        |> PaperTrail.insert!()
+
+      version = Version |> last |> repo.one
+      assert version.item_id == "#{item.id}"
+    end
+  end
+
+  test "versionming models that have a string primary key" do
+    if PaperTrail.Version.__schema__(:type, :item_id) == :string do
+      item =
+        %BarItem{}
+        |> BarItem.changeset(%{item_id: "#{:os.system_time}", title: "hello"})
+        |> PaperTrail.insert!()
+
+      version = Version |> last |> repo.one
+      assert version.item_id == item.item_id
+    end
   end
 end

--- a/test/paper_trail/uuid_test.exs
+++ b/test/paper_trail/uuid_test.exs
@@ -8,7 +8,7 @@ defmodule PaperTrailTest.UUIDTest do
     Application.put_env(:paper_trail, :repo, PaperTrail.UUIDRepo)
     Application.put_env(:paper_trail, :originator, name: :admin, model: Admin)
     Application.put_env(:paper_trail, :originator_type, Ecto.UUID)
-    Application.put_env(:paper_trail, :item_type, (if System.get_env("STR") == nil, do: Ecto.UUID, else: :string))
+    Application.put_env(:paper_trail, :item_type, (if System.get_env("STRING_TEST") == nil, do: Ecto.UUID, else: :string))
     Code.eval_file("lib/paper_trail.ex")
     Code.eval_file("lib/version.ex")
     repo().delete_all(Version)
@@ -59,7 +59,7 @@ defmodule PaperTrailTest.UUIDTest do
     assert version.item_id == item.item_id
   end
 
-  test "versioning models that have a integer primary key" do
+  test "test INTEGER primary key for item_type == :string" do
     if PaperTrail.Version.__schema__(:type, :item_id) == :string do
       item =
         %FooItem{}
@@ -71,7 +71,7 @@ defmodule PaperTrailTest.UUIDTest do
     end
   end
 
-  test "versionming models that have a string primary key" do
+  test "test STRING primary key for item_type == :string" do
     if PaperTrail.Version.__schema__(:type, :item_id) == :string do
       item =
         %BarItem{}

--- a/test/support/uuid_models.exs
+++ b/test/support/uuid_models.exs
@@ -52,3 +52,39 @@ defmodule Item do
     |> validate_required(:title)
   end
 end
+
+defmodule FooItem do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :id, autogenerate: true}
+  schema "foo_items" do
+    field(:title, :string)
+
+    timestamps()
+  end
+
+  def changeset(model, params \\ %{}) do
+    model
+    |> cast(params, [:title])
+    |> validate_required(:title)
+  end
+end
+
+defmodule BarItem do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:item_id, :string, autogenerate: false}
+  schema "bar_items" do
+    field(:title, :string)
+
+    timestamps()
+  end
+
+  def changeset(model, params \\ %{}) do
+    model
+    |> cast(params, [:item_id, :title])
+    |> validate_required([:item_id, :title])
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
+Mix.Task.run("ecto.drop")
 Mix.Task.run("ecto.create")
 Mix.Task.run("ecto.migrate")
 


### PR DESCRIPTION
Two changes:
- Better way to get model id.
- Ecto cannot cast ```integer``` to ```string``` automatically, throw exception while ```item_id``` 
type is ```:string```, ```Ecto.UUID``` <=> ```:string``` is well done.