### PR TITLE
Remove repo module attribute from version_queries

### DIFF
--- a/lib/paper_trail/version_queries.ex
+++ b/lib/paper_trail/version_queries.ex
@@ -2,7 +2,6 @@ defmodule PaperTrail.VersionQueries do
   import Ecto.Query
   alias PaperTrail.Version
 
-
   @doc """
   Gets all the versions of a record.
   """
@@ -29,7 +28,9 @@ defmodule PaperTrail.VersionQueries do
   @spec get_versions(record :: Ecto.Schema.t(), options :: []) :: Ecto.Query.t()
   def get_versions(record, options) when is_map(record) do
     item_type = record.__struct__ |> Module.split() |> List.last()
-    version_query(item_type, PaperTrail.get_model_id(record), options) |> PaperTrail.RepoClient.repo().all
+
+    version_query(item_type, PaperTrail.get_model_id(record), options)
+    |> PaperTrail.RepoClient.repo().all
   end
 
   @doc """
@@ -74,7 +75,9 @@ defmodule PaperTrail.VersionQueries do
   @spec get_version(record :: Ecto.Schema.t(), options :: []) :: Ecto.Query.t()
   def get_version(record, options) when is_map(record) do
     item_type = record.__struct__ |> Module.split() |> List.last()
-    last(version_query(item_type, PaperTrail.get_model_id(record), options)) |> PaperTrail.RepoClient.repo().one
+
+    last(version_query(item_type, PaperTrail.get_model_id(record), options))
+    |> PaperTrail.RepoClient.repo().one
   end
 
   @doc """
@@ -97,7 +100,10 @@ defmodule PaperTrail.VersionQueries do
   Gets the current model record/struct of a version
   """
   def get_current_model(version) do
-    PaperTrail.RepoClient.repo().get(("Elixir." <> version.item_type) |> String.to_existing_atom(), version.item_id)
+    PaperTrail.RepoClient.repo().get(
+      ("Elixir." <> version.item_type) |> String.to_existing_atom(),
+      version.item_id
+    )
   end
 
   defp version_query(item_type, id) do

--- a/lib/paper_trail/version_queries.ex
+++ b/lib/paper_trail/version_queries.ex
@@ -2,7 +2,6 @@ defmodule PaperTrail.VersionQueries do
   import Ecto.Query
   alias PaperTrail.Version
 
-  @repo PaperTrail.RepoClient.repo()
 
   @doc """
   Gets all the versions of a record.
@@ -30,7 +29,7 @@ defmodule PaperTrail.VersionQueries do
   @spec get_versions(record :: Ecto.Schema.t(), options :: []) :: Ecto.Query.t()
   def get_versions(record, options) when is_map(record) do
     item_type = record.__struct__ |> Module.split() |> List.last()
-    version_query(item_type, PaperTrail.get_model_id(record), options) |> @repo.all
+    version_query(item_type, PaperTrail.get_model_id(record), options) |> PaperTrail.RepoClient.repo().all
   end
 
   @doc """
@@ -46,7 +45,7 @@ defmodule PaperTrail.VersionQueries do
   @spec get_versions(model :: module, id :: pos_integer, options :: []) :: Ecto.Query.t()
   def get_versions(model, id, options) do
     item_type = model |> Module.split() |> List.last()
-    version_query(item_type, id, options) |> @repo.all
+    version_query(item_type, id, options) |> PaperTrail.RepoClient.repo().all
   end
 
   @doc """
@@ -75,7 +74,7 @@ defmodule PaperTrail.VersionQueries do
   @spec get_version(record :: Ecto.Schema.t(), options :: []) :: Ecto.Query.t()
   def get_version(record, options) when is_map(record) do
     item_type = record.__struct__ |> Module.split() |> List.last()
-    last(version_query(item_type, PaperTrail.get_model_id(record), options)) |> @repo.one
+    last(version_query(item_type, PaperTrail.get_model_id(record), options)) |> PaperTrail.RepoClient.repo().one
   end
 
   @doc """
@@ -91,14 +90,14 @@ defmodule PaperTrail.VersionQueries do
   @spec get_version(model :: module, id :: pos_integer, options :: []) :: Ecto.Query.t()
   def get_version(model, id, options) do
     item_type = model |> Module.split() |> List.last()
-    last(version_query(item_type, id, options)) |> @repo.one
+    last(version_query(item_type, id, options)) |> PaperTrail.RepoClient.repo().one
   end
 
   @doc """
   Gets the current model record/struct of a version
   """
   def get_current_model(version) do
-    @repo.get(("Elixir." <> version.item_type) |> String.to_existing_atom(), version.item_id)
+    PaperTrail.RepoClient.repo().get(("Elixir." <> version.item_type) |> String.to_existing_atom(), version.item_id)
   end
 
   defp version_query(item_type, id) do


### PR DESCRIPTION
This PR removes the `@repo` module attribute from VersionQueries.
I had the problem 
>     ** (UndefinedFunctionError) function Repo.all/1 is undefined (module Repo is not available)
when I used distillery to create a release.
Compared to other libraries, the usage of module attributes seems to be the difference so I tried to replace them and it worked.
I am still pretty new to Elixir and not sure what exactly the problem was, but my guess is that Distillery compiles every file beforehand and according to this: https://elixir-lang.org/getting-started/module-attributes.html#as-constants 
> Every time an attribute is read inside a function, a snapshot of its current value is taken. In other words, the value is read at compilation time and not at runtime.
it looked like the Repo module was not defined at compilation time.

