### PR TITLE
Support delete with changeset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+.elixir_ls


### PR DESCRIPTION
[Ecto.Repo.delete/2](https://hexdocs.pm/ecto/Ecto.Repo.html#c:delete/2) supports passing a Changeset, but PaperTrail crashes when we try to do that, this PR fixes that.