### PR TITLE
Require postgrex and jason only for dev and test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule PaperTrail.Mixfile do
       {:ecto, "~> 3.3"},
       {:ecto_sql, "~> 3.3"},
       {:ex_doc, ">= 0.20.2", only: :dev},
-      {:postgrex, ">= 0.0.0"},
+      {:postgrex, ">= 0.0.0", only: [:dev, :test]},
       {:jason, "~> 1.0"},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule PaperTrail.Mixfile do
       {:ecto_sql, "~> 3.3"},
       {:ex_doc, ">= 0.20.2", only: :dev},
       {:postgrex, ">= 0.0.0", only: [:dev, :test]},
-      {:jason, "~> 1.0"},
+      {:jason, "~> 1.0", only: [:dev, :test]}
     ]
   end
 


### PR DESCRIPTION
Postgres seems to be used only in these environments, so we can reduce its scope to avoid polluting the client applications that use a different database.
Jason also seems to be used only for testing, db driver libraries have their own json configuration.