### PR TITLE
Make it compatible with mariadb

### DIFF
--- a/lib/version.ex
+++ b/lib/version.ex
@@ -14,7 +14,11 @@ defmodule PaperTrail.Version do
     field(:item_id, Application.get_env(:paper_trail, :item_type, :integer))
     field(:item_changes, :map)
     field(:originator_id, Application.get_env(:paper_trail, :originator_type, :integer))
-    field(:origin, :string, read_after_writes: true)
+
+    field(:origin, :string,
+      read_after_writes: Application.get_env(:paper_trail, :origin_read_after_writes, true)
+    )
+
     field(:meta, :map)
 
     if PaperTrail.RepoClient.originator() do

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule PaperTrail.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [:logger, :postgrex, :ecto, :runtime_tools]
+      applications: [:logger, :ecto, :runtime_tools]
     ]
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
+Application.start(:postgrex)
+
 Mix.Task.run("ecto.drop")
 Mix.Task.run("ecto.create")
 Mix.Task.run("ecto.migrate")


### PR DESCRIPTION
I am really sorry, the last release will break if the client doesn't have postgrex there because it's listed as one of the applications to be started, my bad :/

I have plugged this into an example with myxql to test it now and realized that it can't handle the origin to be read after writing, so I also made it optional.