### PR TITLE
Dump fields using Ecto when serializing changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 *.ez
 .elixir_ls
+.tool-versions

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,3 +19,5 @@ config :paper_trail, PaperTrail.UUIDRepo,
   database: "paper_trail_uuid_test",
   hostname: System.get_env("PG_HOST"),
   poolsize: 10
+
+config :logger, level: :warn

--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -3,6 +3,7 @@ defmodule PaperTrail do
 
   alias PaperTrail.Version
   alias PaperTrail.RepoClient
+  alias PaperTrail.Serializer
 
   defdelegate get_version(record), to: PaperTrail.VersionQueries
   defdelegate get_version(model_or_record, id_or_options), to: PaperTrail.VersionQueries
@@ -11,6 +12,13 @@ defmodule PaperTrail do
   defdelegate get_versions(model_or_record, id_or_options), to: PaperTrail.VersionQueries
   defdelegate get_versions(model, id, options), to: PaperTrail.VersionQueries
   defdelegate get_current_model(version), to: PaperTrail.VersionQueries
+  defdelegate make_version_struct(version, model, options), to: Serializer
+  defdelegate get_sequence_from_model(changeset), to: Serializer
+  defdelegate serialize(data), to: Serializer
+  defdelegate get_sequence_id(table_name), to: Serializer
+  defdelegate add_prefix(changeset, prefix), to: Serializer
+  defdelegate get_item_type(data), to: Serializer
+  defdelegate get_model_id(model), to: Serializer
 
   @doc """
   Inserts a record to the database with a related version insertion in one transaction
@@ -138,108 +146,5 @@ defmodule PaperTrail do
       model
     end)
     |> elem(1)
-  end
-
-  defp make_version_struct(%{event: "insert"}, model, options) do
-    originator = PaperTrail.RepoClient.originator()
-    originator_ref = options[originator[:name]] || options[:originator]
-
-    %Version{
-      event: "insert",
-      item_type: get_item_type(model),
-      item_id: get_model_id(model),
-      item_changes: serialize(model),
-      originator_id:
-        case originator_ref do
-          nil -> nil
-          _ -> originator_ref |> Map.get(:id)
-        end,
-      origin: options[:origin],
-      meta: options[:meta]
-    }
-    |> add_prefix(options[:prefix])
-  end
-
-  defp make_version_struct(%{event: "update"}, changeset, options) do
-    originator = PaperTrail.RepoClient.originator()
-    originator_ref = options[originator[:name]] || options[:originator]
-
-    %Version{
-      event: "update",
-      item_type: get_item_type(changeset),
-      item_id: get_model_id(changeset),
-      item_changes: changeset.changes,
-      originator_id:
-        case originator_ref do
-          nil -> nil
-          _ -> originator_ref |> Map.get(:id)
-        end,
-      origin: options[:origin],
-      meta: options[:meta]
-    }
-    |> add_prefix(options[:prefix])
-  end
-
-  defp make_version_struct(%{event: "delete"}, model_or_changeset, options) do
-    originator = PaperTrail.RepoClient.originator()
-    originator_ref = options[originator[:name]] || options[:originator]
-
-    %Version{
-      event: "delete",
-      item_type: get_item_type(model_or_changeset),
-      item_id: get_model_id(model_or_changeset),
-      item_changes: serialize(model_or_changeset),
-      originator_id:
-        case originator_ref do
-          nil -> nil
-          _ -> originator_ref |> Map.get(:id)
-        end,
-      origin: options[:origin],
-      meta: options[:meta]
-    }
-    |> add_prefix(options[:prefix])
-  end
-
-  defp get_sequence_from_model(changeset) do
-    table_name =
-      case Map.get(changeset, :data) do
-        nil -> changeset.__struct__.__schema__(:source)
-        _ -> changeset.data.__struct__.__schema__(:source)
-      end
-
-    get_sequence_id(table_name)
-  end
-
-  defp get_sequence_id(table_name) do
-    Ecto.Adapters.SQL.query!(RepoClient.repo(), "select last_value FROM #{table_name}_id_seq").rows
-    |> List.first()
-    |> List.first()
-  end
-
-  defp serialize(%Ecto.Changeset{data: data}), do: serialize(data)
-
-  defp serialize(model) do
-    relationships = model.__struct__.__schema__(:associations)
-    Map.drop(model, [:__struct__, :__meta__] ++ relationships)
-  end
-
-  defp add_prefix(changeset, nil), do: changeset
-  defp add_prefix(changeset, prefix), do: Ecto.put_meta(changeset, prefix: prefix)
-
-  defp get_item_type(%Ecto.Changeset{data: data}), do: get_item_type(data)
-  defp get_item_type(model), do: model.__struct__ |> Module.split() |> List.last()
-
-  def get_model_id(%Ecto.Changeset{data: data}), do: get_model_id(data)
-
-  def get_model_id(model) do
-    {_, model_id} = List.first(Ecto.primary_key(model))
-
-    case PaperTrail.Version.__schema__(:type, :item_id) do
-      :integer ->
-        model_id
-
-      _ ->
-        "#{model_id}"
-    end
   end
 end

--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -13,10 +13,9 @@ defmodule PaperTrail do
   defdelegate get_versions(model, id, options), to: PaperTrail.VersionQueries
   defdelegate get_current_model(version), to: PaperTrail.VersionQueries
   defdelegate make_version_struct(version, model, options), to: Serializer
-  defdelegate get_sequence_from_model(changeset), to: Serializer
   defdelegate serialize(data), to: Serializer
   defdelegate get_sequence_id(table_name), to: Serializer
-  defdelegate add_prefix(changeset, prefix), to: Serializer
+  defdelegate add_prefix(schema, prefix), to: Serializer
   defdelegate get_item_type(data), to: Serializer
   defdelegate get_model_id(model), to: Serializer
 
@@ -44,7 +43,7 @@ defmodule PaperTrail do
           changeset_data =
             Map.get(changeset, :data, changeset)
             |> Map.merge(%{
-              id: get_sequence_from_model(changeset) + 1,
+              id: get_sequence_id(changeset) + 1,
               first_version_id: version_id,
               current_version_id: version_id
             })

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -16,10 +16,9 @@ defmodule PaperTrail.Multi do
   defdelegate run(multi, name, mod, fun, args), to: Ecto.Multi
   defdelegate to_list(multi), to: Ecto.Multi
   defdelegate make_version_struct(version, model, options), to: Serializer
-  defdelegate get_sequence_from_model(changeset), to: Serializer
   defdelegate serialize(data), to: Serializer
   defdelegate get_sequence_id(table_name), to: Serializer
-  defdelegate add_prefix(changeset, prefix), to: Serializer
+  defdelegate add_prefix(schema, prefix), to: Serializer
   defdelegate get_item_type(data), to: Serializer
   defdelegate get_model_id(model), to: Serializer
 
@@ -39,7 +38,7 @@ defmodule PaperTrail.Multi do
           changeset_data =
             Map.get(changeset, :data, changeset)
             |> Map.merge(%{
-              id: get_sequence_from_model(changeset) + 1,
+              id: get_sequence_id(changeset) + 1,
               first_version_id: version_id,
               current_version_id: version_id
             })

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -4,6 +4,7 @@ defmodule PaperTrail.Multi do
   alias PaperTrail
   alias PaperTrail.Version
   alias PaperTrail.RepoClient
+  alias PaperTrail.Serializer
 
   defdelegate new(), to: Ecto.Multi
   defdelegate append(lhs, rhs), to: Ecto.Multi
@@ -14,6 +15,13 @@ defmodule PaperTrail.Multi do
   defdelegate run(multi, name, run), to: Ecto.Multi
   defdelegate run(multi, name, mod, fun, args), to: Ecto.Multi
   defdelegate to_list(multi), to: Ecto.Multi
+  defdelegate make_version_struct(version, model, options), to: Serializer
+  defdelegate get_sequence_from_model(changeset), to: Serializer
+  defdelegate serialize(data), to: Serializer
+  defdelegate get_sequence_id(table_name), to: Serializer
+  defdelegate add_prefix(changeset, prefix), to: Serializer
+  defdelegate get_item_type(data), to: Serializer
+  defdelegate get_model_id(model), to: Serializer
 
   def insert(%Ecto.Multi{} = multi, changeset, options \\ [
     origin: nil, meta: nil, originator: nil, prefix: nil, model_key: :model, version_key: :version, ecto_options: []
@@ -144,109 +152,6 @@ defmodule PaperTrail.Multi do
           {:error, :model, changeset, %{}} -> {:error, Map.merge(changeset, %{repo: repo})}
           _ -> transaction
         end
-    end
-  end
-
-  defp make_version_struct(%{event: "insert"}, model, options) do
-    originator = PaperTrail.RepoClient.originator()
-    originator_ref = options[originator[:name]] || options[:originator]
-
-    %Version{
-      event: "insert",
-      item_type: get_item_type(model),
-      item_id: get_model_id(model),
-      item_changes: serialize(model),
-      originator_id:
-        case originator_ref do
-          nil -> nil
-          _ -> originator_ref |> Map.get(:id)
-        end,
-      origin: options[:origin],
-      meta: options[:meta]
-    }
-    |> add_prefix(options[:prefix])
-  end
-
-  defp make_version_struct(%{event: "update"}, changeset, options) do
-    originator = PaperTrail.RepoClient.originator()
-    originator_ref = options[originator[:name]] || options[:originator]
-
-    %Version{
-      event: "update",
-      item_type: get_item_type(changeset),
-      item_id: get_model_id(changeset),
-      item_changes: changeset.changes,
-      originator_id:
-        case originator_ref do
-          nil -> nil
-          _ -> originator_ref |> Map.get(:id)
-        end,
-      origin: options[:origin],
-      meta: options[:meta]
-    }
-    |> add_prefix(options[:prefix])
-  end
-
-  defp make_version_struct(%{event: "delete"}, model_or_changeset, options) do
-    originator = PaperTrail.RepoClient.originator()
-    originator_ref = options[originator[:name]] || options[:originator]
-
-    %Version{
-      event: "delete",
-      item_type: get_item_type(model_or_changeset),
-      item_id: get_model_id(model_or_changeset),
-      item_changes: serialize(model_or_changeset),
-      originator_id:
-        case originator_ref do
-          nil -> nil
-          _ -> originator_ref |> Map.get(:id)
-        end,
-      origin: options[:origin],
-      meta: options[:meta]
-    }
-    |> add_prefix(options[:prefix])
-  end
-
-  defp get_sequence_from_model(changeset) do
-    table_name =
-      case Map.get(changeset, :data) do
-        nil -> changeset.__struct__.__schema__(:source)
-        _ -> changeset.data.__struct__.__schema__(:source)
-      end
-
-    get_sequence_id(table_name)
-  end
-
-  defp get_sequence_id(table_name) do
-    Ecto.Adapters.SQL.query!(RepoClient.repo(), "select last_value FROM #{table_name}_id_seq").rows
-    |> List.first()
-    |> List.first()
-  end
-
-  defp serialize(%Ecto.Changeset{data: data}), do: serialize(data)
-
-  defp serialize(model) do
-    relationships = model.__struct__.__schema__(:associations)
-    Map.drop(model, [:__struct__, :__meta__] ++ relationships)
-  end
-
-  defp add_prefix(changeset, nil), do: changeset
-  defp add_prefix(changeset, prefix), do: Ecto.put_meta(changeset, prefix: prefix)
-
-  defp get_item_type(%Ecto.Changeset{data: data}), do: get_item_type(data)
-  defp get_item_type(model), do: model.__struct__ |> Module.split() |> List.last()
-
-  defp get_model_id(%Ecto.Changeset{data: data}), do: get_model_id(data)
-
-  defp get_model_id(model) do
-    {_, model_id} = List.first(Ecto.primary_key(model))
-
-    case PaperTrail.Version.__schema__(:type, :item_id) do
-      :integer ->
-        model_id
-
-      _ ->
-        "#{model_id}"
     end
   end
 end

--- a/lib/paper_trail/serializer.ex
+++ b/lib/paper_trail/serializer.ex
@@ -1,0 +1,110 @@
+defmodule PaperTrail.Serializer do
+
+  alias PaperTrail.RepoClient
+  alias PaperTrail.Version
+
+  def make_version_struct(%{event: "insert"}, model, options) do
+    originator = RepoClient.originator()
+    originator_ref = options[originator[:name]] || options[:originator]
+
+    %Version{
+      event: "insert",
+      item_type: get_item_type(model),
+      item_id: get_model_id(model),
+      item_changes: serialize(model),
+      originator_id:
+        case originator_ref do
+          nil -> nil
+          _ -> originator_ref |> Map.get(:id)
+        end,
+      origin: options[:origin],
+      meta: options[:meta]
+    }
+    |> add_prefix(options[:prefix])
+  end
+
+  def make_version_struct(%{event: "update"}, changeset, options) do
+    originator = RepoClient.originator()
+    originator_ref = options[originator[:name]] || options[:originator]
+
+    %Version{
+      event: "update",
+      item_type: get_item_type(changeset),
+      item_id: get_model_id(changeset),
+      item_changes: changeset.changes,
+      originator_id:
+        case originator_ref do
+          nil -> nil
+          _ -> originator_ref |> Map.get(:id)
+        end,
+      origin: options[:origin],
+      meta: options[:meta]
+    }
+    |> add_prefix(options[:prefix])
+  end
+
+  def make_version_struct(%{event: "delete"}, model_or_changeset, options) do
+    originator = RepoClient.originator()
+    originator_ref = options[originator[:name]] || options[:originator]
+
+    %Version{
+      event: "delete",
+      item_type: get_item_type(model_or_changeset),
+      item_id: get_model_id(model_or_changeset),
+      item_changes: serialize(model_or_changeset),
+      originator_id:
+        case originator_ref do
+          nil -> nil
+          _ -> originator_ref |> Map.get(:id)
+        end,
+      origin: options[:origin],
+      meta: options[:meta]
+    }
+    |> add_prefix(options[:prefix])
+  end
+
+  def get_sequence_from_model(changeset) do
+    table_name =
+      case Map.get(changeset, :data) do
+        nil -> changeset.__struct__.__schema__(:source)
+        _ -> changeset.data.__struct__.__schema__(:source)
+      end
+
+    get_sequence_id(table_name)
+  end
+
+  def get_sequence_id(table_name) do
+    Ecto.Adapters.SQL.query!(RepoClient.repo(), "select last_value FROM #{table_name}_id_seq").rows
+    |> List.first()
+    |> List.first()
+  end
+
+  def serialize(nil), do: nil
+
+  def serialize(%Ecto.Changeset{data: data}), do: serialize(data)
+
+  def serialize(model) do
+    relationships = model.__struct__.__schema__(:associations)
+    Map.drop(model, [:__struct__, :__meta__] ++ relationships)
+  end
+
+  def add_prefix(changeset, nil), do: changeset
+  def add_prefix(changeset, prefix), do: Ecto.put_meta(changeset, prefix: prefix)
+
+  def get_item_type(%Ecto.Changeset{data: data}), do: get_item_type(data)
+  def get_item_type(%schema{}), do: schema |> Module.split() |> List.last()
+
+  def get_model_id(%Ecto.Changeset{data: data}), do: get_model_id(data)
+
+  def get_model_id(model) do
+    {_, model_id} = List.first(Ecto.primary_key(model))
+
+    case PaperTrail.Version.__schema__(:type, :item_id) do
+      :integer ->
+        model_id
+
+      _ ->
+        "#{model_id}"
+    end
+  end
+end

--- a/lib/paper_trail/serializer.ex
+++ b/lib/paper_trail/serializer.ex
@@ -95,7 +95,7 @@ defmodule PaperTrail.Serializer do
   end
 
   @doc """
-  Dumps the whole struct using Ecto fields
+  Shows DB representation of an Ecto model, filters relationships and virtual attributes from an Ecto.Changeset or %ModelStruct{}
   """
   @spec serialize(nil | Ecto.Changeset.t() | struct()) :: nil | map()
   def serialize(nil), do: nil

--- a/lib/version.ex
+++ b/lib/version.ex
@@ -4,6 +4,8 @@ defmodule PaperTrail.Version do
   import Ecto.Changeset
   import Ecto.Query
 
+  @type t :: %__MODULE__{}
+
   # @setter PaperTrail.RepoClient.originator()
   # @item_type Application.get_env(:paper_trail, :item_type, :integer)
   # @originator_type Application.get_env(:paper_trail, :originator_type, :integer)

--- a/priv/repo/migrations/20160619190937_add_simple_companies.exs
+++ b/priv/repo/migrations/20160619190937_add_simple_companies.exs
@@ -11,6 +11,7 @@ defmodule Repo.Migrations.CreateSimpleCompanies do
       add :facebook,   :string
       add :twitter,    :string
       add :founded_in, :string
+      add :location,   :map
 
       timestamps()
     end

--- a/test/paper_trail/bang_functions_simple_mode_test.exs
+++ b/test/paper_trail/bang_functions_simple_mode_test.exs
@@ -7,6 +7,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
   alias SimpleCompany, as: Company
   alias SimplePerson, as: Person
   alias PaperTrailTest.MultiTenantHelper, as: MultiTenant
+  alias PaperTrail.RepoClient
+  alias PaperTrail.Serializer
 
   @create_company_params %{name: "Acme LLC", is_active: true, city: "Greenwich"}
   @update_company_params %{
@@ -14,6 +16,9 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
     website: "http://www.acme.com",
     facebook: "acme.llc"
   }
+
+  defdelegate repo, to: RepoClient
+  defdelegate serialize(data), to: Serializer
 
   doctest PaperTrail
 
@@ -787,7 +792,7 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
     assert person == first_person(:multitenant) |> serialize
   end
 
-  test "[multi tenant] updating a person creates a person version with correct attributes" do
+  test "[multi tenant] updating a person creates a person version with correct attributes" do
     tenant = MultiTenant.tenant()
 
     inserted_initial_company =
@@ -993,11 +998,6 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
     first(Person, :id) |> MultiTenant.add_prefix_to_query() |> repo().one()
   end
 
-  defp serialize(model) do
-    relationships = model.__struct__.__schema__(:associations)
-    Map.drop(model, [:__struct__, :__meta__] ++ relationships)
-  end
-
   defp reset_all_data() do
     repo().delete_all(Person)
     repo().delete_all(Company)
@@ -1018,9 +1018,5 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
 
   defp convert_to_string_map(map) do
     map |> Jason.encode!() |> Jason.decode!()
-  end
-
-  defp repo() do
-    PaperTrail.RepoClient.repo()
   end
 end

--- a/test/paper_trail/bang_functions_simple_mode_test.exs
+++ b/test/paper_trail/bang_functions_simple_mode_test.exs
@@ -62,7 +62,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              address: nil,
              facebook: nil,
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -127,7 +128,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -176,7 +178,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -234,7 +237,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -253,7 +257,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
                  address: nil,
                  facebook: "acme.llc",
                  twitter: nil,
-                 founded_in: nil
+                 founded_in: nil,
+                 location: nil
                }),
              originator_id: user.id,
              origin: nil,
@@ -501,7 +506,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              address: nil,
              facebook: nil,
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -557,7 +563,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -613,7 +620,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -681,7 +689,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -700,7 +709,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
                  address: nil,
                  facebook: "acme.llc",
                  twitter: nil,
-                 founded_in: nil
+                 founded_in: nil,
+                 location: nil
                }),
              originator_id: user.id,
              origin: nil,
@@ -710,7 +720,7 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
     assert company == company_before_deletion
   end
 
-  test "[multi tenant] PaperTrail.delete!/2 with an error raises Ecto.InvalidChangesetError" do
+  test "[multi tenant] PaperTrail.delete!/2 with an error raises Ecto.InvalidChangesetError" do
     tenant = MultiTenant.tenant()
 
     assert_raise(Ecto.InvalidChangesetError, fn ->

--- a/test/paper_trail/bang_functions_strict_mode_test.exs
+++ b/test/paper_trail/bang_functions_strict_mode_test.exs
@@ -7,6 +7,8 @@ defmodule PaperTrailTest.StrictModeBangFunctions do
   alias StrictCompany, as: Company
   alias StrictPerson, as: Person
   alias PaperTrailTest.MultiTenantHelper, as: MultiTenant
+  alias PaperTrail.RepoClient
+  alias PaperTrail.Serializer
 
   @create_company_params %{name: "Acme LLC", is_active: true, city: "Greenwich"}
   @update_company_params %{
@@ -14,6 +16,9 @@ defmodule PaperTrailTest.StrictModeBangFunctions do
     website: "http://www.acme.com",
     facebook: "acme.llc"
   }
+
+  defdelegate repo, to: RepoClient
+  defdelegate serialize(data), to: Serializer
 
   doctest PaperTrail
 
@@ -1020,11 +1025,6 @@ defmodule PaperTrailTest.StrictModeBangFunctions do
     first(Person, :id) |> MultiTenant.add_prefix_to_query() |> repo().one()
   end
 
-  defp serialize(model) do
-    relationships = model.__struct__.__schema__(:associations)
-    Map.drop(model, [:__struct__, :__meta__] ++ relationships)
-  end
-
   defp reset_all_data() do
     repo().delete_all(Person)
     repo().delete_all(Company)
@@ -1047,7 +1047,4 @@ defmodule PaperTrailTest.StrictModeBangFunctions do
     map |> Jason.encode!() |> Jason.decode!()
   end
 
-  defp repo() do
-    PaperTrail.RepoClient.repo()
-  end
 end

--- a/test/paper_trail/base_test.exs
+++ b/test/paper_trail/base_test.exs
@@ -9,11 +9,17 @@ defmodule PaperTrailTest do
   alias PaperTrail.Serializer
 
   @repo PaperTrail.RepoClient.repo()
-  @create_company_params %{name: "Acme LLC", is_active: true, city: "Greenwich"}
+  @create_company_params %{
+    name: "Acme LLC",
+    is_active: true,
+    city: "Greenwich",
+    location: %{country: "Brazil"}
+  }
   @update_company_params %{
     city: "Hong Kong",
     website: "http://www.acme.com",
-    facebook: "acme.llc"
+    facebook: "acme.llc",
+    location: %{country: "Chile"}
   }
 
   defdelegate serialize(data), to: Serializer
@@ -64,7 +70,8 @@ defmodule PaperTrailTest do
              address: nil,
              facebook: nil,
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: %{country: "Brazil"}
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -134,7 +141,8 @@ defmodule PaperTrailTest do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: %{country: "Chile"}
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -144,7 +152,8 @@ defmodule PaperTrailTest do
              item_changes: %{
                city: "Hong Kong",
                website: "http://www.acme.com",
-               facebook: "acme.llc"
+               facebook: "acme.llc",
+               location: %{country: "Chile"}
              },
              originator_id: user.id,
              origin: nil,
@@ -183,7 +192,8 @@ defmodule PaperTrailTest do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: %{country: "Chile"}
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -193,7 +203,8 @@ defmodule PaperTrailTest do
              item_changes: %{
                city: "Hong Kong",
                website: "http://www.acme.com",
-               facebook: "acme.llc"
+               facebook: "acme.llc",
+               location: %{country: "Chile"}
              },
              originator_id: user.id,
              origin: nil,
@@ -252,7 +263,8 @@ defmodule PaperTrailTest do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: %{country: "Chile"}
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -270,7 +282,8 @@ defmodule PaperTrailTest do
                address: nil,
                facebook: "acme.llc",
                twitter: nil,
-               founded_in: nil
+               founded_in: nil,
+               location: %{country: "Chile"}
              },
              originator_id: user.id,
              origin: nil,
@@ -307,7 +320,8 @@ defmodule PaperTrailTest do
              address: nil,
              facebook: "acme.llc",
              twitter: nil,
-             founded_in: nil
+             founded_in: nil,
+             location: %{country: "Chile"}
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -325,7 +339,8 @@ defmodule PaperTrailTest do
                address: nil,
                facebook: "acme.llc",
                twitter: nil,
-               founded_in: nil
+               founded_in: nil,
+               location: %{country: "Chile"}
              },
              originator_id: user.id,
              origin: nil,

--- a/test/paper_trail/base_test.exs
+++ b/test/paper_trail/base_test.exs
@@ -283,7 +283,7 @@ defmodule PaperTrailTest do
   test "delete works with a changeset" do
     user = create_user()
     {:ok, insert_result} = create_company_with_version()
-    {:ok, update_result} = update_company_with_version(insert_result[:model])
+    {:ok, _update_result} = update_company_with_version(insert_result[:model])
     company_before_deletion = first(Company, :id) |> @repo.one
 
     changeset = Company.changeset(company_before_deletion, %{})

--- a/test/paper_trail/base_test.exs
+++ b/test/paper_trail/base_test.exs
@@ -6,6 +6,7 @@ defmodule PaperTrailTest do
   alias PaperTrail.Version
   alias SimpleCompany, as: Company
   alias SimplePerson, as: Person
+  alias PaperTrail.Serializer
 
   @repo PaperTrail.RepoClient.repo()
   @create_company_params %{name: "Acme LLC", is_active: true, city: "Greenwich"}
@@ -14,6 +15,8 @@ defmodule PaperTrailTest do
     website: "http://www.acme.com",
     facebook: "acme.llc"
   }
+
+  defdelegate serialize(data), to: Serializer
 
   doctest PaperTrail
 
@@ -551,10 +554,5 @@ defmodule PaperTrailTest do
 
   defp update_company_with_version(company, params \\ @update_company_params, options \\ []) do
     Company.changeset(company, params) |> PaperTrail.update(options)
-  end
-
-  defp serialize(model) do
-    relationships = model.__struct__.__schema__(:associations)
-    Map.drop(model, [:__struct__, :__meta__] ++ relationships)
   end
 end

--- a/test/paper_trail/strict_mode_test.exs
+++ b/test/paper_trail/strict_mode_test.exs
@@ -7,6 +7,7 @@ defmodule PaperTrailStrictModeTest do
   alias PaperTrail.Version
   alias StrictCompany, as: Company
   alias StrictPerson, as: Person
+  alias PaperTrail.Serializer
 
   @repo PaperTrail.RepoClient.repo()
   @create_company_params %{name: "Acme LLC", is_active: true, city: "Greenwich"}
@@ -15,6 +16,8 @@ defmodule PaperTrailStrictModeTest do
     website: "http://www.acme.com",
     facebook: "acme.llc"
   }
+
+  defdelegate serialize(data), to: Serializer
 
   doctest PaperTrail
 
@@ -498,10 +501,5 @@ defmodule PaperTrailStrictModeTest do
 
   defp update_company_with_version(company, params \\ @update_company_params, options \\ []) do
     Company.changeset(company, params) |> PaperTrail.update(options)
-  end
-
-  defp serialize(model) do
-    relationships = model.__struct__.__schema__(:associations)
-    Map.drop(model, [:__struct__, :__meta__] ++ relationships)
   end
 end

--- a/test/support/simple_models.exs
+++ b/test/support/simple_models.exs
@@ -1,3 +1,32 @@
+
+defmodule LocationType do
+  use Ecto.Type
+
+  defstruct [:country]
+
+  @impl true
+  def type, do: :map
+
+  @impl true
+  def embed_as(_format), do: :dump
+
+  @impl true
+  def cast(%__MODULE__{} = location), do: {:ok, location}
+  def cast(%{} = data), do: {:ok, struct!(__MODULE__, data)}
+  def cast(_), do: :error
+
+  @impl true
+  def load(data) when is_map(data) do
+    data = Enum.map(data, fn {key, val} -> {String.to_existing_atom(key), val} end)
+
+    {:ok, struct!(__MODULE__, data)}
+  end
+
+  @impl true
+  def dump(%__MODULE__{} = location), do: {:ok, Map.from_struct(location)}
+  def dump(_), do: :error
+end
+
 defmodule SimpleCompany do
   use Ecto.Schema
 
@@ -15,13 +44,24 @@ defmodule SimpleCompany do
     field(:facebook, :string)
     field(:twitter, :string)
     field(:founded_in, :string)
+    field(:location, LocationType)
 
     has_many(:people, SimplePerson, foreign_key: :company_id)
 
     timestamps()
   end
 
-  @optional_fields ~w(name is_active website city address facebook twitter founded_in)a
+  @optional_fields ~w(
+    name
+    is_active
+    website
+    city
+    address
+    facebook
+    twitter
+    founded_in
+    location
+  )a
 
   def changeset(model, params \\ %{}) do
     model
@@ -61,7 +101,14 @@ defmodule SimplePerson do
     timestamps()
   end
 
-  @optional_fields ~w(first_name last_name visit_count gender birthdate company_id)a
+  @optional_fields ~w(
+    first_name
+    last_name
+    visit_count
+    gender
+    birthdate
+    company_id
+  )a
 
   def changeset(model, params \\ %{}) do
     model

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,10 +7,10 @@ Mix.Task.run("ecto.migrate")
 PaperTrail.Repo.start_link()
 PaperTrail.UUIDRepo.start_link()
 
+Code.require_file("test/support/multi_tenant_helper.exs")
 Code.require_file("test/support/simple_models.exs")
 Code.require_file("test/support/strict_models.exs")
 Code.require_file("test/support/uuid_models.exs")
-Code.require_file("test/support/multi_tenant_helper.exs")
 
 ExUnit.configure(seed: 0)
 

--- a/test/version/paper_trail_version_test.exs
+++ b/test/version/paper_trail_version_test.exs
@@ -3,6 +3,8 @@ defmodule PaperTrailTest.Version do
 
   alias PaperTrail.Version
   alias PaperTrailTest.MultiTenantHelper, as: MultiTenant
+  alias PaperTrail.RepoClient
+  alias PaperTrail.Serializer
 
   @valid_attrs %{
     event: "insert",
@@ -13,6 +15,9 @@ defmodule PaperTrailTest.Version do
     inserted_at: DateTime.from_naive!(~N[1952-04-01 01:00:00], "Etc/UTC")
   }
   @invalid_attrs %{}
+
+  defdelegate repo, to: RepoClient
+  defdelegate serialize(data), to: Serializer
 
   setup_all do
     Application.put_env(:paper_trail, :strict_mode, false)
@@ -165,16 +170,5 @@ defmodule PaperTrailTest.Version do
       prefix: prefix
     )
     |> elem(1)
-  end
-
-  def serialize(nil), do: nil
-
-  def serialize(resource) do
-    relationships = resource.__struct__.__schema__(:associations)
-    Map.drop(resource, [:__meta__, :__struct__] ++ relationships)
-  end
-
-  defp repo() do
-    PaperTrail.RepoClient.repo()
   end
 end

--- a/test/version/version_queries_test.exs
+++ b/test/version/version_queries_test.exs
@@ -5,8 +5,11 @@ defmodule PaperTrailTest.VersionQueries do
   alias SimpleCompany, as: Company
   alias SimplePerson, as: Person
   alias PaperTrailTest.MultiTenantHelper, as: MultiTenant
+  alias PaperTrail.RepoClient
 
   import Ecto.Query
+
+  defdelegate repo, to: RepoClient
 
   setup_all do
     Application.put_env(:paper_trail, :repo, PaperTrail.Repo)
@@ -191,9 +194,5 @@ defmodule PaperTrailTest.VersionQueries do
     Version
     |> MultiTenant.add_prefix_to_query()
     |> repo().delete_all()
-  end
-
-  defp repo() do
-    PaperTrail.RepoClient.repo()
   end
 end


### PR DESCRIPTION
- [x] Dump fields using Ecto when serializing changes

[Ecto.embedded_dump/2](https://hexdocs.pm/ecto/Ecto.html#embedded_dump/2) is now called when serializing changes, which means custom Ecto fields have their [dump/1](https://hexdocs.pm/ecto/Ecto.Type.html#c:dump/1) callback called if their callback [embed_as/1](https://hexdocs.pm/ecto/Ecto.Type.html#c:embed_as/1) return `:dump` (default is `:self`).

These changes were done only in this commit: https://github.com/rschef/paper_trail/commit/1c97a580ccbfb77c4da9da363d99607446aee569

- [x] Fixed `test/paper_trail/base_tests.exs` file not being run, because it didn't end with the sufix `_test.exs`

- [x] Created `PaperTrail.Serializer` module and reused it across the application

The following functions were being declared in multiple modules, although they had the same implementation. 

Now all modules delegate to the `PaperTrail.Serializer` module:

```elixir
  defdelegate make_version_struct(version, model, options), to: Serializer
  defdelegate get_sequence_from_model(changeset), to: Serializer
  defdelegate serialize(data), to: Serializer
  defdelegate get_sequence_id(table_name), to: Serializer
  defdelegate add_prefix(changeset, prefix), to: Serializer
  defdelegate get_item_type(data), to: Serializer
  defdelegate get_model_id(model), to: Serializer
```