### PR TITLE
Ability to delete multiple features and to initialise existing record

### DIFF
--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -23,10 +23,8 @@ defmodule PaperTrail do
         make_version_struct(%{event: "insert"}, model, options)
         |> repo.insert!()
 
-        true
-
       _ ->
-        false
+        :error
     end
   end
 

--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -13,6 +13,22 @@ defmodule PaperTrail do
   defdelegate get_current_model(version), to: PaperTrail.VersionQueries
 
   @doc """
+  Intialise paper_trail for existing record
+  """
+  def initialise(model, options \\ [origin: nil, meta: nil, originator: nil, prefix: nil, version_key: :version]) do
+    case get_version(model) do
+      nil ->
+        repo = RepoClient.repo()
+
+        make_version_struct(%{event: "insert"}, model, options)
+        |> repo.insert!()
+
+      _ ->
+        :error
+    end
+  end
+
+  @doc """
   Inserts a record to the database with a related version insertion in one transaction
   """
   def insert(changeset, options \\ [origin: nil, meta: nil, originator: nil, prefix: nil, model_key: :model, version_key: :version]) do

--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -23,8 +23,10 @@ defmodule PaperTrail do
         make_version_struct(%{event: "insert"}, model, options)
         |> repo.insert!()
 
+        true
+
       _ ->
-        :error
+        false
     end
   end
 

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -120,7 +120,7 @@ defmodule PaperTrail.Multi do
       _ ->
         multi
         |> Ecto.Multi.update(model_key, changeset)
-        |> Ecto.Multi.run(version_key, fn repo, %{model: _model} ->
+        |> Ecto.Multi.run(version_key, fn repo, %{^model_key => _model} ->
           version = make_version_struct(%{event: "update"}, changeset, options)
           repo.insert(version)
         end)

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -103,11 +103,11 @@ defmodule PaperTrail.Multi do
           target_version = make_version_struct(%{event: "update"}, target_changeset, options)
           repo.insert(target_version)
         end)
-        |> Ecto.Multi.run(:model, fn repo, %{initial_version: initial_version} ->
+        |> Ecto.Multi.run(model_key, fn repo, %{initial_version: initial_version} ->
           updated_changeset = changeset |> change(%{current_version_id: initial_version.id})
           repo.update(updated_changeset)
         end)
-        |> Ecto.Multi.run(:version, fn repo, %{initial_version: initial_version} ->
+        |> Ecto.Multi.run(version_key, fn repo, %{initial_version: initial_version} ->
           new_item_changes =
             initial_version.item_changes
             |> Map.merge(%{
@@ -119,8 +119,8 @@ defmodule PaperTrail.Multi do
 
       _ ->
         multi
-        |> Ecto.Multi.update(:model, changeset)
-        |> Ecto.Multi.run(:version, fn repo, %{model: _model} ->
+        |> Ecto.Multi.update(model_key, changeset)
+        |> Ecto.Multi.run(version_key, fn repo, %{model: _model} ->
           version = make_version_struct(%{event: "update"}, changeset, options)
           repo.insert(version)
         end)

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -110,11 +110,14 @@ defmodule PaperTrail.Multi do
   def delete(
         %Ecto.Multi{} = multi,
         struct,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
+        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil, model_key: :model, version_key: :version]
       ) do
+    model_key = options[:model_key] || :model
+    version_key = options[:version_key] || :version
+
     multi
-    |> Ecto.Multi.delete(:model, struct, options)
-    |> Ecto.Multi.run(:version, fn repo, %{} ->
+    |> Ecto.Multi.delete(model_key, struct, options)
+    |> Ecto.Multi.run(version_key, fn repo, %{} ->
       version = make_version_struct(%{event: "delete"}, struct, options)
       repo.insert(version, options)
     end)

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -15,9 +15,18 @@ defmodule PaperTrail.Multi do
   defdelegate run(multi, name, mod, fun, args), to: Ecto.Multi
   defdelegate to_list(multi), to: Ecto.Multi
 
-  def insert(%Ecto.Multi{} = multi, changeset, options \\ [
-    origin: nil, meta: nil, originator: nil, prefix: nil, model_key: :model, version_key: :version
-  ]) do
+  def insert(
+        %Ecto.Multi{} = multi,
+        changeset,
+        options \\ [
+          origin: nil,
+          meta: nil,
+          originator: nil,
+          prefix: nil,
+          model_key: :model,
+          version_key: :version
+        ]
+      ) do
     model_key = options[:model_key] || :model
     version_key = options[:version_key] || :version
 
@@ -48,7 +57,8 @@ defmodule PaperTrail.Multi do
 
           repo.insert(updated_changeset)
         end)
-        |> Ecto.Multi.run(version_key, fn repo, %{initial_version: initial_version, model: model} ->
+        |> Ecto.Multi.run(version_key, fn repo,
+                                          %{initial_version: initial_version, model: model} ->
           target_version = make_version_struct(%{event: "insert"}, model, options) |> serialize()
 
           Version.changeset(initial_version, target_version) |> repo.update
@@ -67,8 +77,18 @@ defmodule PaperTrail.Multi do
   def update(
         %Ecto.Multi{} = multi,
         changeset,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
+        options \\ [
+          origin: nil,
+          meta: nil,
+          originator: nil,
+          prefix: nil,
+          model_key: :model,
+          version_key: :version
+        ]
       ) do
+    model_key = options[:model_key] || :model
+    version_key = options[:version_key] || :version
+
     case RepoClient.strict_mode() do
       true ->
         multi
@@ -110,7 +130,14 @@ defmodule PaperTrail.Multi do
   def delete(
         %Ecto.Multi{} = multi,
         struct,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil, model_key: :model, version_key: :version]
+        options \\ [
+          origin: nil,
+          meta: nil,
+          originator: nil,
+          prefix: nil,
+          model_key: :model,
+          version_key: :version
+        ]
       ) do
     model_key = options[:model_key] || :model
     version_key = options[:version_key] || :version


### PR DESCRIPTION
- change to PaperTrail.Multi.delete/3 to enable reception of model_key and version_key to execute multiple deletions (on the model of Ecto.Multi.insert/3
- add PaperTrail.initialise/2 to have function that explicitly initialise an already existing record into versions table