### PR TITLE
PaperTrail creates an update version even when there's no update

### DIFF
--- a/test/paper_trail/base_tests.exs
+++ b/test/paper_trail/base_tests.exs
@@ -136,6 +136,19 @@ defmodule PaperTrailTest do
     assert company == first(Company, :id) |> @repo.one |> serialize
   end
 
+  test "updating a company with current params does not create a version" do
+    {:ok, insert_result} = create_company_with_version()
+
+    {:ok, update_result} =
+      update_company_with_version(
+        insert_result[:model],
+        @create_company_params,
+        []
+      )
+
+    assert PaperTrail.get_version(insert_result[:model]) == insert_result[:version]
+  end
+
   test "updating a company with originator[user] creates a correct company version" do
     user = create_user()
     {:ok, insert_result} = create_company_with_version()


### PR DESCRIPTION
Hi there, I found that PaperTrail creates an update version, even if there are no changes in the changeset and so there's not really an update. This was surprising to me, and I'd like to understand the rationale if this is intentional - and for a suggestion on how to proceed if I don't want this behavior. One possibility I can think of is constructing the version myself when needed, essentially duplicating the current behavior of `PaperTrail.update`. Another possibility is to add an option to PaperTrail to not create versions on no-op updates. I have included a failing test demonstrating what I consider surprising behavior.

Here's the failure message. You can see that `item_changes` in the update version is `%{}`, so I don't think it warrants a PaperTrail version.

```
  1) test updating a company with current params does not create a version (PaperTrailTest)
     test/paper_trail/base_tests.exs:139
     Assertion with == failed
     code:  assert PaperTrail.get_version(insert_result[:model]) == insert_result[:version]
     left:  %PaperTrail.Version{
              __meta__: #Ecto.Schema.Metadata<:loaded, "versions">,
              event: "update",
              id: 2,
              inserted_at: ~N[2020-08-25 18:00:44],
              item_changes: %{},
              item_id: 1,
              item_type: "SimpleCompany",
              meta: nil,
              origin: nil,
              originator_id: nil,
              user: #Ecto.Association.NotLoaded<association :user is not loaded>
            }
     right: %PaperTrail.Version{
              __meta__: #Ecto.Schema.Metadata<:loaded, "versions">,
              event: "insert",
              id: 1,
              inserted_at: ~N[2020-08-25 18:00:44],
              item_changes: %{
                address: nil,
                city: "Greenwich",
                facebook: nil,
                founded_in: nil,
                id: 1,
                inserted_at: ~N[2020-08-25 18:00:44],
                is_active: true,
                name: "Acme LLC",
                twitter: nil,
                updated_at: ~N[2020-08-25 18:00:44],
                website: nil
              },
              item_id: 1,
              item_type: "SimpleCompany",
              meta: nil,
              origin: nil,
              originator_id: nil,
              user: #Ecto.Association.NotLoaded<association :user is not loaded>
            }
     stacktrace:
       test/paper_trail/base_tests.exs:149: (test)
```