### PR TITLE
Require ex_doc dependency only for ":docs".

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule PaperTrail.Mixfile do
     [
       {:ecto, ">= 3.4.0"},
       {:ecto_sql, ">= 3.4.0"},
-      {:ex_doc, ">= 0.21.3"},
+      {:ex_doc, ">= 0.21.3", only: :docs},
       {:postgrex, ">= 0.0.0", only: [:dev, :test]},
       {:jason, ">= 1.2.0", only: [:dev, :test]}
     ]


### PR DESCRIPTION
So that Hex packages earmark_parser, makeup, makeup_elixir, and nimble_parsec aren't pulled in to users of this library.

(The [tests on CI](https://app.circleci.com/pipelines/github/izelnakri/paper_trail/) were already failing and as far as I can tell, this change doesn't make more tests fail.)