### PR TITLE
add support for ecto options in insert and insert! functions

### DIFF
--- a/priv/repo/migrations/20200827222744_add_uniqueness_constraint_to_companies_name.exs
+++ b/priv/repo/migrations/20200827222744_add_uniqueness_constraint_to_companies_name.exs
@@ -1,0 +1,8 @@
+defmodule PaperTrail.Repo.Migrations.AddUniquenessConstraintToCompaniesName do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:simple_companies, [:name])
+    create unique_index(:strict_companies, [:name])
+  end
+end

--- a/test/paper_trail/bang_functions_simple_mode_test.exs
+++ b/test/paper_trail/bang_functions_simple_mode_test.exs
@@ -79,6 +79,21 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
     end)
   end
 
+  test "PaperTrail.insert!/2 passes ecto options through (e.g. upsert options)" do
+    user = create_user()
+    _result = create_company_with_version(@create_company_params, [originator: user])
+
+    new_create_company_params = @create_company_params |> Map.replace!(:city, "Barcelona")
+
+    ecto_options =  [on_conflict: {:replace_all_except, ~w{name}a}, conflict_target: :name]
+    result = create_company_with_version(new_create_company_params, [originator: user, ecto_options: ecto_options])
+
+    assert Company.count() == 1
+    assert Version.count() == 2
+
+    assert Map.take(serialize(result), [:name, :city]) == %{name: "Acme LLC", city: "Barcelona"}
+  end
+
   test "updating a company with originator creates a correct company version" do
     user = create_user()
     inserted_company = create_company_with_version()

--- a/test/paper_trail/bang_functions_strict_mode_test.exs
+++ b/test/paper_trail/bang_functions_strict_mode_test.exs
@@ -117,6 +117,21 @@ defmodule PaperTrailTest.StrictModeBangFunctions do
     end)
   end
 
+  test "PaperTrail.insert!/2 passes ecto options through (e.g. upsert options)" do
+    user = create_user()
+    _result = create_company_with_version(@create_company_params, [originator: user])
+
+    new_create_company_params = @create_company_params |> Map.replace!(:city, "Barcelona")
+
+    ecto_options =  [on_conflict: {:replace_all_except, ~w{name}a}, conflict_target: :name]
+    result = create_company_with_version(new_create_company_params, [originator: user, ecto_options: ecto_options])
+
+    assert Company.count() == 1
+    assert Version.count() == 2
+
+    assert Map.take(serialize(result), [:name, :city]) == %{name: "Acme LLC", city: "Barcelona"}
+  end
+
   test "updating a company creates a company version with correct item_changes" do
     user = create_user()
     inserted_company = create_company_with_version()

--- a/test/paper_trail/base_test.exs
+++ b/test/paper_trail/base_test.exs
@@ -87,6 +87,21 @@ defmodule PaperTrailTest do
     assert result == ecto_result
   end
 
+  test "PaperTrail.insert/2 passes ecto options through (e.g. upsert options)" do
+    user = create_user()
+    {:ok, _result} = create_company_with_version(@create_company_params, [originator: user])
+
+    new_create_company_params = @create_company_params |> Map.replace!(:city, "Barcelona")
+
+    ecto_options =  [on_conflict: {:replace_all_except, ~w{name}a}, conflict_target: :name]
+    {:ok, result} = create_company_with_version(new_create_company_params, [originator: user, ecto_options: ecto_options])
+
+    assert Company.count() == 1
+    assert Version.count() == 2
+
+    assert Map.take(serialize(result[:model]), [:name, :city]) == %{name: "Acme LLC", city: "Barcelona"}
+  end
+
   test "updating a company with originator creates a correct company version" do
     user = create_user()
     {:ok, insert_result} = create_company_with_version()


### PR DESCRIPTION
Pass through any ecto options to `insert` and `insert!`. This does not (yet) thread the options through to`update` and `update!`. If it is acceptable as is, we can add the option to updates on a new pull request 😎 

This might address https://github.com/izelnakri/paper_trail/issues/32
