### PR TITLE
Make Version schema's timestamps type configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,18 @@ id = 1
 PaperTrail.get_versions(User, id, [prefix: tenant])
 ```
 
+## Version timestamps
+
+PaperTrail can be configured to use `utc_datetime` or `utc_datetime_usec` for Version timestamps.
+
+```elixir
+# in your config/config.exs
+
+config :paper_trail, timestamps_type: :utc_datetime
+```
+
+Note: You will need to recompile your deps after you have added the config for timestamps.
+
 ## Suggestions
 - PaperTrail.Version(s) order matter,
 - don't delete your paper_trail versions, instead you can merge them

--- a/lib/mix/tasks/papertrail/install.ex
+++ b/lib/mix/tasks/papertrail/install.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Papertrail.Install do
           add :origin,       :string, size: 50
           add :meta,         :map
           
-          # Configure timestamps time in :paper_trail :timestamps_type
+          # Configure timestamps type in config.ex :paper_trail :timestamps_type
           add :inserted_at,  :#{timestamps_type}, null: false
         end
 

--- a/lib/mix/tasks/papertrail/install.ex
+++ b/lib/mix/tasks/papertrail/install.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Papertrail.Install do
   def run(_args) do
     path = Path.relative_to("priv/repo/migrations", Mix.Project.app_path())
     file = Path.join(path, "#{timestamp()}_#{underscore(AddVersions)}.exs")
-    timestamps_type = Application.get_env(:paper_trail, :timestamps_type, :utc_datetime)
+    timestamps_type = Application.get_env(:paper_trail, :timestamps_type, :naive_datetime)
 
     create_directory(path)
 

--- a/lib/mix/tasks/papertrail/install.ex
+++ b/lib/mix/tasks/papertrail/install.ex
@@ -9,6 +9,8 @@ defmodule Mix.Tasks.Papertrail.Install do
   def run(_args) do
     path = Path.relative_to("priv/repo/migrations", Mix.Project.app_path())
     file = Path.join(path, "#{timestamp()}_#{underscore(AddVersions)}.exs")
+    timestamps_type = Application.get_env(:paper_trail, :timestamps_type, :utc_datetime)
+
     create_directory(path)
 
     create_file(file, """
@@ -24,8 +26,9 @@ defmodule Mix.Tasks.Papertrail.Install do
           add :originator_id, references(:users) # you can change :users to your own foreign key constraint
           add :origin,       :string, size: 50
           add :meta,         :map
-
-          add :inserted_at,  :utc_datetime, null: false
+          
+          # Configure timestamps time in :paper_trail :timestamps_type
+          add :inserted_at,  :#{timestamps_type}, null: false
         end
 
         create index(:versions, [:originator_id])

--- a/lib/mix/tasks/papertrail/install.ex
+++ b/lib/mix/tasks/papertrail/install.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Papertrail.Install do
   def run(_args) do
     path = Path.relative_to("priv/repo/migrations", Mix.Project.app_path())
     file = Path.join(path, "#{timestamp()}_#{underscore(AddVersions)}.exs")
-    timestamps_type = Application.get_env(:paper_trail, :timestamps_type, :naive_datetime)
+    timestamps_type = Application.get_env(:paper_trail, :timestamps_type, :utc_datetime)
 
     create_directory(path)
 

--- a/lib/version.ex
+++ b/lib/version.ex
@@ -31,7 +31,7 @@ defmodule PaperTrail.Version do
       )
     end
 
-    timestamps(updated_at: false)
+    timestamps(updated_at: false, type: Application.get_env(:paper_trail, :timestamps_type, :naive_datetime))
   end
 
   def changeset(model, params \\ :empty) do

--- a/lib/version.ex
+++ b/lib/version.ex
@@ -31,7 +31,10 @@ defmodule PaperTrail.Version do
       )
     end
 
-    timestamps(updated_at: false, type: Application.get_env(:paper_trail, :timestamps_type, :naive_datetime))
+    timestamps(
+      updated_at: false,
+      type: Application.get_env(:paper_trail, :timestamps_type, :utc_datetime)
+    )
   end
 
   def changeset(model, params \\ :empty) do


### PR DESCRIPTION
Add support for different `timestamp` types for the `Version` schema.

Currently only the default `naive_datetime` can be used. In order to use `utc_datetime` or `utc_datetime_usec` it should be specified as a type option.

This PR adds a configuration field which for this purpose, namely `:paper_trail, :timestamps_type`.