### PR TITLE
Support Ecto Embed

### DIFF
--- a/priv/repo/migrations/20160619190938_add_simple_people.exs
+++ b/priv/repo/migrations/20160619190938_add_simple_people.exs
@@ -8,6 +8,8 @@ defmodule Repo.Migrations.CreateSimplePeople do
       add :visit_count, :integer
       add :gender, :boolean
       add :birthdate, :date
+      add :singular, :map
+      add :plural, {:array, :map}
 
       add :company_id, references(:simple_companies), null: false
 

--- a/test/paper_trail/bang_functions_simple_mode_test.exs
+++ b/test/paper_trail/bang_functions_simple_mode_test.exs
@@ -326,7 +326,9 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              gender: true,
              visit_count: nil,
              birthdate: nil,
-             company_id: second_company.id
+             company_id: second_company.id,
+             plural: [],
+             singular: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -340,6 +342,39 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
            }
 
     assert person == first(Person, :id) |> repo().one |> serialize
+  end
+
+  test "creating a person with embeds creates a person version with correct attributes" do
+    company = create_company_with_version()
+
+    %Person{
+      id: person_id,
+      plural: [%{id: _, name: "Plural"}],
+      singular: %{id: _, name: "Singular"}
+    } =
+      person =
+      %Person{}
+      |> Person.changeset(%{
+        first_name: "Izel",
+        last_name: "Nakri",
+        gender: true,
+        company_id: company.id,
+        plural: [%{name: "Plural"}],
+        singular: %{name: "Singular"}
+      })
+      |> PaperTrail.insert!()
+
+    version = PaperTrail.get_version(person)
+    person_change = person |> serialize() |> convert_to_string_map
+
+    assert %{
+             event: "insert",
+             item_type: "SimplePerson",
+             item_id: ^person_id,
+             item_changes: ^person_change
+           } = version
+
+    assert person == first(Person, :id) |> repo().one
   end
 
   test "updating a person creates a person version with correct attributes" do
@@ -391,7 +426,9 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              visit_count: 10,
              birthdate: ~D[1992-04-01],
              last_name: "Nakri",
-             gender: true
+             gender: true,
+             plural: [],
+             singular: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -411,6 +448,44 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
            }
 
     assert person == first(Person, :id) |> repo().one |> serialize
+  end
+
+  test "updating a person with embeds creates a person version with correct attributes" do
+    company = create_company_with_version()
+
+    %Person{
+      id: person_id,
+      plural: [%{id: _, name: "Plural"}],
+      singular: %{id: _, name: "Singular"}
+    } =
+      person =
+      %Person{}
+      |> Person.changeset(%{
+        first_name: "Izel",
+        last_name: "Nakri",
+        gender: true,
+        company_id: company.id
+      })
+      |> PaperTrail.insert!()
+      |> Person.changeset(%{
+        plural: [%{name: "Plural"}],
+        singular: %{name: "Singular"}
+      })
+      |> PaperTrail.update!()
+
+    version = PaperTrail.get_version(person)
+
+    assert %{
+             event: "update",
+             item_type: "SimplePerson",
+             item_id: ^person_id,
+             item_changes: %{
+               "plural" => [%{"id" => _, "name" => "Plural"}],
+               "singular" => %{"id" => _, "name" => "Singular"}
+             }
+           } = version
+
+    assert person == first(Person, :id) |> repo().one
   end
 
   test "deleting a person creates a person version with correct attributes" do
@@ -475,7 +550,9 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
                  gender: true,
                  visit_count: 10,
                  birthdate: ~D[1992-04-01],
-                 company_id: inserted_target_company.id
+                 company_id: inserted_target_company.id,
+                 plural: [],
+                 singular: nil
                }),
              originator_id: nil,
              origin: "admin",
@@ -483,6 +560,40 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
            }
 
     assert old_person == person_before_deletion
+  end
+
+  test "deleting a person with embeds creates a person version with correct attributes" do
+    company = create_company_with_version()
+
+    %Person{
+      id: person_id,
+      plural: [%{id: _, name: "Plural"}],
+      singular: %{id: _, name: "Singular"}
+    } =
+      person =
+      %Person{}
+      |> Person.changeset(%{
+        first_name: "Izel",
+        last_name: "Nakri",
+        gender: true,
+        company_id: company.id,
+        plural: [%{name: "Plural"}],
+        singular: %{name: "Singular"}
+      })
+      |> PaperTrail.insert!()
+      |> PaperTrail.delete!()
+
+    version = PaperTrail.get_version(person)
+    person_change = person |> serialize() |> convert_to_string_map
+
+    assert %{
+             event: "delete",
+             item_type: "SimplePerson",
+             item_id: ^person_id,
+             item_changes: ^person_change
+           } = version
+
+    assert is_nil(first(Person, :id) |> repo().one)
   end
 
   # Multi tenant tests
@@ -791,7 +902,9 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              gender: true,
              visit_count: nil,
              birthdate: nil,
-             company_id: second_company.id
+             company_id: second_company.id,
+             plural: [],
+             singular: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -863,7 +976,9 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              visit_count: 10,
              birthdate: ~D[1992-04-01],
              last_name: "Nakri",
-             gender: true
+             gender: true,
+             plural: [],
+             singular: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -955,7 +1070,9 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
                  gender: true,
                  visit_count: 10,
                  birthdate: ~D[1992-04-01],
-                 company_id: inserted_target_company.id
+                 company_id: inserted_target_company.id,
+                 plural: [],
+                 singular: nil
                }),
              originator_id: nil,
              origin: "admin",

--- a/test/paper_trail/base_test.exs
+++ b/test/paper_trail/base_test.exs
@@ -411,7 +411,9 @@ defmodule PaperTrailTest do
              gender: true,
              visit_count: nil,
              birthdate: nil,
-             company_id: new_company_result[:model].id
+             company_id: new_company_result[:model].id,
+             plural: [],
+             singular: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -475,7 +477,9 @@ defmodule PaperTrailTest do
              visit_count: 10,
              birthdate: ~D[1992-04-01],
              last_name: "Nakri",
-             gender: true
+             gender: true,
+             plural: [],
+             singular: nil
            }
 
     assert Map.drop(version, [:id, :inserted_at]) == %{
@@ -557,7 +561,9 @@ defmodule PaperTrailTest do
                gender: true,
                visit_count: 10,
                birthdate: ~D[1992-04-01],
-               company_id: target_company_insertion[:model].id
+               company_id: target_company_insertion[:model].id,
+               plural: [],
+               singular: nil
              },
              originator_id: nil,
              origin: "admin",

--- a/test/support/simple_models.exs
+++ b/test/support/simple_models.exs
@@ -97,6 +97,9 @@ defmodule SimplePerson do
 
     belongs_to(:company, SimpleCompany, foreign_key: :company_id)
 
+    embeds_one(:singular, SimpleEmbed)
+    embeds_many(:plural, SimpleEmbed)
+
     timestamps()
   end
 
@@ -113,6 +116,8 @@ defmodule SimplePerson do
     model
     |> cast(params, @optional_fields)
     |> foreign_key_constraint(:company_id)
+    |> cast_embed(:singular)
+    |> cast_embed(:plural)
   end
 
   def count do
@@ -123,5 +128,20 @@ defmodule SimplePerson do
     from(record in __MODULE__, select: count(record.id))
     |> MultiTenant.add_prefix_to_query()
     |> PaperTrail.RepoClient.repo().one
+  end
+end
+
+defmodule SimpleEmbed do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  embedded_schema do
+    field(:name, :string)
+  end
+
+  def changeset(model, params \\ %{}) do
+    model
+    |> cast(params, [:name])
   end
 end


### PR DESCRIPTION
Replaces the functionality of embeds in #21, #30 and #60

For associations there's an easy point to hook in in the `Serializer` as well.

* [x] Merge #124 first