### PR TITLE
Cleanup Public API / Docs

### DIFF
--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -1,19 +1,37 @@
 defmodule PaperTrail do
+  import Ecto.Query, only: [from: 2, last: 1]
+
   alias PaperTrail.Version
   alias PaperTrail.Serializer
 
-  defdelegate get_version(record), to: PaperTrail.VersionQueries
-  defdelegate get_version(model_or_record, id_or_options), to: PaperTrail.VersionQueries
-  defdelegate get_version(model, id, options), to: PaperTrail.VersionQueries
-  defdelegate get_versions(record), to: PaperTrail.VersionQueries
-  defdelegate get_versions(model_or_record, id_or_options), to: PaperTrail.VersionQueries
-  defdelegate get_versions(model, id, options), to: PaperTrail.VersionQueries
-  defdelegate get_current_model(version), to: PaperTrail.VersionQueries
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate make_version_struct(version, model, options), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate serialize(data), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_sequence_id(table_name), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate add_prefix(schema, prefix), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_item_type(data), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_model_id(model), to: Serializer
 
   @doc """
@@ -22,19 +40,8 @@ defmodule PaperTrail do
   @spec insert(changeset :: Ecto.Changeset.t(model), options :: Keyword.t()) ::
           {:ok, %{model: model, version: Version.t()}} | {:error, Ecto.Changeset.t(model) | term}
         when model: struct
-  def insert(
-        changeset,
-        options \\ [
-          origin: nil,
-          meta: nil,
-          originator: nil,
-          prefix: nil,
-          model_key: :model,
-          version_key: :version,
-          ecto_options: []
-        ]
-      ) do
-    PaperTrail.Multi.new()
+  def insert(changeset, options \\ []) do
+    Ecto.Multi.new()
     |> PaperTrail.Multi.insert(changeset, options)
     |> PaperTrail.Multi.commit()
   end
@@ -44,18 +51,7 @@ defmodule PaperTrail do
   """
   @spec insert!(changeset :: Ecto.Changeset.t(model), options :: Keyword.t()) :: model
         when model: struct
-  def insert!(
-        changeset,
-        options \\ [
-          origin: nil,
-          meta: nil,
-          originator: nil,
-          prefix: nil,
-          model_key: :model,
-          version_key: :version,
-          ecto_options: []
-        ]
-      ) do
+  def insert!(changeset, options \\ []) do
     changeset
     |> insert(options)
     |> model_or_error(:insert)
@@ -67,8 +63,8 @@ defmodule PaperTrail do
   @spec update(changeset :: Ecto.Changeset.t(model), options :: Keyword.t()) ::
           {:ok, %{model: model, version: Version.t()}} | {:error, Ecto.Changeset.t(model) | term}
         when model: struct
-  def update(changeset, options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]) do
-    PaperTrail.Multi.new()
+  def update(changeset, options \\ []) do
+    Ecto.Multi.new()
     |> PaperTrail.Multi.update(changeset, options)
     |> PaperTrail.Multi.commit()
   end
@@ -78,7 +74,7 @@ defmodule PaperTrail do
   """
   @spec update!(changeset :: Ecto.Changeset.t(model), options :: Keyword.t()) :: model
         when model: struct
-  def update!(changeset, options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]) do
+  def update!(changeset, options \\ []) do
     changeset
     |> update(options)
     |> model_or_error(:update)
@@ -90,11 +86,8 @@ defmodule PaperTrail do
   @spec delete(model_or_changeset :: model | Ecto.Changeset.t(model), options :: Keyword.t()) ::
           {:ok, %{model: model, version: Version.t()}} | {:error, Ecto.Changeset.t(model) | term}
         when model: struct
-  def delete(
-        model_or_changeset,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
-      ) do
-    PaperTrail.Multi.new()
+  def delete(model_or_changeset, options \\ []) do
+    Ecto.Multi.new()
     |> PaperTrail.Multi.delete(model_or_changeset, options)
     |> PaperTrail.Multi.commit()
   end
@@ -105,13 +98,104 @@ defmodule PaperTrail do
   @spec delete!(model_or_changeset :: model | Ecto.Changeset.t(model), options :: Keyword.t()) ::
           model
         when model: struct
-  def delete!(
-        model_or_changeset,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
-      ) do
+  def delete!(model_or_changeset, options \\ []) do
     model_or_changeset
     |> delete(options)
     |> model_or_error(:delete)
+  end
+
+  @doc """
+  Gets all the versions of a record.
+
+  A list of options is optional, so you can set for example the :prefix of the query,
+  wich allows you to change between different tenants.
+
+  # Usage examples:
+
+      iex> PaperTrail.VersionQueries.get_versions(record)
+      iex> PaperTrail.VersionQueries.get_versions(record, [prefix: "tenant_id"])
+      iex> PaperTrail.VersionQueries.get_versions(ModelName, id)
+      iex> PaperTrail.VersionQueries.get_versions(ModelName, id, [prefix: "tenant_id"])
+  """
+  @spec get_versions(record :: Ecto.Schema.t()) :: [Version.t()]
+  def get_versions(record), do: get_versions(record, [])
+
+  @doc """
+  Gets all the versions of a record given a module and its id
+  """
+  @spec get_versions(model :: module, id :: pos_integer) :: [Version.t()]
+  def get_versions(model, id) when is_atom(model) and is_integer(id),
+    do: get_versions(model, id, [])
+
+  @spec get_versions(record :: Ecto.Schema.t(), options :: Keyword.t()) :: [Version.t()]
+  def get_versions(record, options) when is_map(record) do
+    item_type = record.__struct__ |> Module.split() |> List.last()
+
+    version_query(item_type, Serializer.get_model_id(record), options)
+    |> PaperTrail.RepoClient.repo().all
+  end
+
+  @spec get_versions(model :: module, id :: pos_integer, options :: Keyword.t()) :: [Version.t()]
+  def get_versions(model, id, options) do
+    item_type = model |> Module.split() |> List.last()
+    version_query(item_type, id, options) |> PaperTrail.RepoClient.repo().all
+  end
+
+  @doc """
+  Gets the last version of a record.
+
+  A list of options is optional, so you can set for example the :prefix of the query,
+  wich allows you to change between different tenants.
+
+  # Usage examples:
+
+      iex> PaperTrail.VersionQueries.get_version(record, id)
+      iex> PaperTrail.VersionQueries.get_version(record, [prefix: "tenant_id"])
+      iex> PaperTrail.VersionQueries.get_version(ModelName, id)
+      iex> PaperTrail.VersionQueries.get_version(ModelName, id, [prefix: "tenant_id"])
+  """
+  @spec get_version(record :: Ecto.Schema.t()) :: Version.t() | nil
+  def get_version(record), do: get_version(record, [])
+
+  @spec get_version(model :: module, id :: pos_integer) :: Version.t() | nil
+  def get_version(model, id) when is_atom(model) and is_integer(id),
+    do: get_version(model, id, [])
+
+  @spec get_version(record :: Ecto.Schema.t(), options :: Keyword.t()) :: Version.t() | nil
+  def get_version(record, options) when is_map(record) do
+    item_type = record.__struct__ |> Module.split() |> List.last()
+
+    last(version_query(item_type, Serializer.get_model_id(record), options))
+    |> PaperTrail.RepoClient.repo().one
+  end
+
+  @spec get_version(model :: module, id :: pos_integer, options :: []) :: Version.t() | nil
+  def get_version(model, id, options) do
+    item_type = model |> Module.split() |> List.last()
+    last(version_query(item_type, id, options)) |> PaperTrail.RepoClient.repo().one
+  end
+
+  @doc """
+  Gets the current model record/struct of a version
+  """
+  @spec get_current_model(version :: Version.t()) :: Ecto.Schema.t() | nil
+  def get_current_model(version) do
+    PaperTrail.RepoClient.repo().get(
+      ("Elixir." <> version.item_type) |> String.to_existing_atom(),
+      version.item_id
+    )
+  end
+
+  defp version_query(item_type, id) do
+    from(v in Version, where: v.item_type == ^item_type and v.item_id == ^id)
+  end
+
+  defp version_query(item_type, id, options) do
+    with opts <- Enum.into(options, %{}) do
+      version_query(item_type, id)
+      |> Ecto.Queryable.to_query()
+      |> Map.merge(opts)
+    end
   end
 
   @spec model_or_error(result :: {:ok, %{model: model}}, action :: :insert | :update | :delete) ::

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -1,4 +1,8 @@
 defmodule PaperTrail.Multi do
+  @moduledoc false
+  # TODO: Will be documented again as soon as the insert / update / delete
+  # functions are overhauled
+
   import Ecto.Changeset
 
   alias PaperTrail
@@ -6,35 +10,82 @@ defmodule PaperTrail.Multi do
   alias PaperTrail.RepoClient
   alias PaperTrail.Serializer
 
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.new/0"
   defdelegate new(), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.append/2"
   defdelegate append(lhs, rhs), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.error/3"
   defdelegate error(multi, name, value), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.merge/2"
   defdelegate merge(multi, merge), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.merge/4"
   defdelegate merge(multi, mod, fun, args), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.prepend/2"
   defdelegate prepend(lhs, rhs), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.run/3"
   defdelegate run(multi, name, run), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.run/5"
   defdelegate run(multi, name, mod, fun, args), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.to_list/1"
   defdelegate to_list(multi), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate make_version_struct(version, model, options), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate serialize(data), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_sequence_id(table_name), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate add_prefix(schema, prefix), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_item_type(data), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_model_id(model), to: Serializer
 
-  def insert(
-        %Ecto.Multi{} = multi,
-        changeset,
-        options \\ [
-          origin: nil,
-          meta: nil,
-          originator: nil,
-          prefix: nil,
-          model_key: :model,
-          version_key: :version,
-          ecto_options: []
-        ]
-      ) do
+  def insert(%Ecto.Multi{} = multi, changeset, options \\ []) do
     model_key = options[:model_key] || :model
     version_key = options[:version_key] || :version
     ecto_options = options[:ecto_options] || []
@@ -83,11 +134,7 @@ defmodule PaperTrail.Multi do
     end
   end
 
-  def update(
-        %Ecto.Multi{} = multi,
-        changeset,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
-      ) do
+  def update(%Ecto.Multi{} = multi, changeset, options \\ []) do
     case RepoClient.strict_mode() do
       true ->
         multi
@@ -126,11 +173,7 @@ defmodule PaperTrail.Multi do
     end
   end
 
-  def delete(
-        %Ecto.Multi{} = multi,
-        struct,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
-      ) do
+  def delete(%Ecto.Multi{} = multi, struct, options \\ []) do
     multi
     |> Ecto.Multi.delete(:model, struct, options)
     |> Ecto.Multi.run(:version, fn repo, %{} ->

--- a/lib/paper_trail/repo_client.ex
+++ b/lib/paper_trail/repo_client.ex
@@ -1,4 +1,6 @@
 defmodule PaperTrail.RepoClient do
+  @moduledoc false
+
   @doc """
   Gets the configured repo module or defaults to Repo if none configured
   """

--- a/lib/paper_trail/serializer.ex
+++ b/lib/paper_trail/serializer.ex
@@ -1,7 +1,6 @@
 defmodule PaperTrail.Serializer do
-  @moduledoc """
-  Serialization functions to create a version struct
-  """
+  @moduledoc false
+  # Serialization functions to create a version struct
 
   alias PaperTrail.RepoClient
   alias PaperTrail.Version

--- a/lib/paper_trail/version_queries.ex
+++ b/lib/paper_trail/version_queries.ex
@@ -1,98 +1,32 @@
 defmodule PaperTrail.VersionQueries do
-  import Ecto.Query
-  alias PaperTrail.Version
+  @moduledoc false
+  # TODO: Remove Module with next major release
 
-  @doc """
-  Gets all the versions of a record.
+  @doc false
+  @deprecated "Use PaperTrail.get_version/1"
+  defdelegate get_version(record), to: PaperTrail
 
-  A list of options is optional, so you can set for example the :prefix of the query,
-  wich allows you to change between different tenants.
+  @doc false
+  @deprecated "Use PaperTrail.get_version/2"
+  defdelegate get_version(model_or_record, id_or_options), to: PaperTrail
 
-  # Usage examples:
+  @doc false
+  @deprecated "Use PaperTrail.get_version/3"
+  defdelegate get_version(model, id, options), to: PaperTrail
 
-    iex(1)> PaperTrail.VersionQueries.get_versions(record)
-    iex(1)> PaperTrail.VersionQueries.get_versions(record, [prefix: "tenant_id"])
-    iex(1)> PaperTrail.VersionQueries.get_versions(ModelName, id)
-    iex(1)> PaperTrail.VersionQueries.get_versions(ModelName, id, [prefix: "tenant_id"])
-  """
-  @spec get_versions(record :: Ecto.Schema.t()) :: [Version.t()]
-  def get_versions(record), do: get_versions(record, [])
+  @doc false
+  @deprecated "Use PaperTrail.get_versions/1"
+  defdelegate get_versions(record), to: PaperTrail
 
-  @doc """
-  Gets all the versions of a record given a module and its id
-  """
-  @spec get_versions(model :: module, id :: pos_integer) :: [Version.t()]
-  def get_versions(model, id) when is_atom(model) and is_integer(id),
-    do: get_versions(model, id, [])
+  @doc false
+  @deprecated "Use PaperTrail.get_versions/2"
+  defdelegate get_versions(model_or_record, id_or_options), to: PaperTrail
 
-  @spec get_versions(record :: Ecto.Schema.t(), options :: []) :: [Version.t()]
-  def get_versions(record, options) when is_map(record) do
-    item_type = record.__struct__ |> Module.split() |> List.last()
+  @doc false
+  @deprecated "Use PaperTrail.get_versions/3"
+  defdelegate get_versions(model, id, options), to: PaperTrail
 
-    version_query(item_type, PaperTrail.get_model_id(record), options)
-    |> PaperTrail.RepoClient.repo().all
-  end
-
-  @spec get_versions(model :: module, id :: pos_integer, options :: []) :: [Version.t()]
-  def get_versions(model, id, options) do
-    item_type = model |> Module.split() |> List.last()
-    version_query(item_type, id, options) |> PaperTrail.RepoClient.repo().all
-  end
-
-  @doc """
-  Gets the last version of a record.
-
-  A list of options is optional, so you can set for example the :prefix of the query,
-  wich allows you to change between different tenants.
-
-  # Usage examples:
-
-    iex(1)> PaperTrail.VersionQueries.get_version(record, id)
-    iex(1)> PaperTrail.VersionQueries.get_version(record, [prefix: "tenant_id"])
-    iex(1)> PaperTrail.VersionQueries.get_version(ModelName, id)
-    iex(1)> PaperTrail.VersionQueries.get_version(ModelName, id, [prefix: "tenant_id"])
-  """
-  @spec get_version(record :: Ecto.Schema.t()) :: Version.t() | nil
-  def get_version(record), do: get_version(record, [])
-
-  @spec get_version(model :: module, id :: pos_integer) :: Version.t() | nil
-  def get_version(model, id) when is_atom(model) and is_integer(id),
-    do: get_version(model, id, [])
-
-  @spec get_version(record :: Ecto.Schema.t(), options :: []) :: Version.t() | nil
-  def get_version(record, options) when is_map(record) do
-    item_type = record.__struct__ |> Module.split() |> List.last()
-
-    last(version_query(item_type, PaperTrail.get_model_id(record), options))
-    |> PaperTrail.RepoClient.repo().one
-  end
-
-  @spec get_version(model :: module, id :: pos_integer, options :: []) :: Version.t() | nil
-  def get_version(model, id, options) do
-    item_type = model |> Module.split() |> List.last()
-    last(version_query(item_type, id, options)) |> PaperTrail.RepoClient.repo().one
-  end
-
-  @doc """
-  Gets the current model record/struct of a version
-  """
-  @spec get_current_model(version :: Version.t()) :: Ecto.Schema.t() | nil
-  def get_current_model(version) do
-    PaperTrail.RepoClient.repo().get(
-      ("Elixir." <> version.item_type) |> String.to_existing_atom(),
-      version.item_id
-    )
-  end
-
-  defp version_query(item_type, id) do
-    from(v in Version, where: v.item_type == ^item_type and v.item_id == ^id)
-  end
-
-  defp version_query(item_type, id, options) do
-    with opts <- Enum.into(options, %{}) do
-      version_query(item_type, id)
-      |> Ecto.Queryable.to_query()
-      |> Map.merge(opts)
-    end
-  end
+  @doc false
+  @deprecated "Use PaperTrail.get_current_model/1"
+  defdelegate get_current_model(version), to: PaperTrail
 end

--- a/test/paper_trail/bang_functions_simple_mode_test.exs
+++ b/test/paper_trail/bang_functions_simple_mode_test.exs
@@ -20,8 +20,6 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
   defdelegate repo, to: RepoClient
   defdelegate serialize(data), to: Serializer
 
-  doctest PaperTrail
-
   setup_all do
     Application.put_env(:paper_trail, :strict_mode, false)
     Application.put_env(:paper_trail, :repo, PaperTrail.Repo)

--- a/test/paper_trail/bang_functions_strict_mode_test.exs
+++ b/test/paper_trail/bang_functions_strict_mode_test.exs
@@ -20,8 +20,6 @@ defmodule PaperTrailTest.StrictModeBangFunctions do
   defdelegate repo, to: RepoClient
   defdelegate serialize(data), to: Serializer
 
-  doctest PaperTrail
-
   setup_all do
     Application.put_env(:paper_trail, :strict_mode, true)
     Application.put_env(:paper_trail, :repo, PaperTrail.Repo)

--- a/test/paper_trail/base_test.exs
+++ b/test/paper_trail/base_test.exs
@@ -24,7 +24,7 @@ defmodule PaperTrailTest do
 
   defdelegate serialize(data), to: Serializer
 
-  doctest PaperTrail
+  doctest PaperTrail, except: [get_version: 1, get_versions: 1]
 
   setup_all do
     Application.put_env(:paper_trail, :strict_mode, false)
@@ -591,7 +591,7 @@ defmodule PaperTrailTest do
       })
       |> PaperTrail.insert(origin: "admin")
 
-    assert {:ok, insert_person_result} =
+    assert {:ok, _insert_person_result} =
              Person.changeset(insert_person_result[:model], %{
                singular: nil
              })

--- a/test/paper_trail/strict_mode_test.exs
+++ b/test/paper_trail/strict_mode_test.exs
@@ -19,8 +19,6 @@ defmodule PaperTrailStrictModeTest do
 
   defdelegate serialize(data), to: Serializer
 
-  doctest PaperTrail
-
   setup_all do
     Application.put_env(:paper_trail, :strict_mode, true)
     Application.put_env(:paper_trail, :repo, PaperTrail.Repo)


### PR DESCRIPTION
This PR cleans up the publicly exposed APIs / Docs.

I'll add a PR next that will re-expose the `PaperTrail.Multi` functions with a few small changes.

## Deprecations / Reasons for the Deprecation

* `PaperTrail.VersionQueries.*` - Function was published both in `PaperTrail` and `PaperTrail.VersionQueries`. To have a clean / concise API the function will now be exclusively in `PaperTrail`.
* `PaperTrail.serialize/1` - I consider this API internal and it should not be publicly used.
* `PaperTrail.get_sequence_id/1` - I consider this API internal and it should not be publicly used.
* `PaperTrail.add_prefix/2` - I consider this API internal and it should not be publicly used.
* `PaperTrail.get_item_type/1` - I consider this API internal and it should not be publicly used.
* `PaperTrail.get_model_id/1` - I consider this API internal and it should not be publicly used.
* `PaperTrail.Multi.serialize/1` - I consider this API internal and it should not be publicly used.
* `PaperTrail.Multi.get_sequence_id/1` - I consider this API internal and it should not be publicly used.
* `PaperTrail.Multi.add_prefix/2` - I consider this API internal and it should not be publicly used.
* `PaperTrail.Multi.get_item_type/1` - I consider this API internal and it should not be publicly used.
* `PaperTrail.Multi.get_model_id/1` - I consider this API internal and it should not be publicly used.
* `PaperTrail.Multi.insert,update,delete,commit` - All Functions currently only really work for the use case that fulfills `PaperTrail.update.insert,delete,commit`. It can not be used for actual Multi operations since there will be duplicated names (`initial_version`) in the `Multi`. This will be remedied by #132 
* `PaperTrail.Multi.* serializer related` - See above
* `PaperTrail.Multi.* multi related` - Those functions duplicate the functions of `Ecto.Multi`. They should be used directly. Otherwise people will probably think that `Ecto.Multi` functions are incompatible with `PaperTrail.Multi`.