### PR TITLE
Expose PapertTrail Multi Functions

### DIFF
--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -1,19 +1,37 @@
 defmodule PaperTrail do
+  import Ecto.Query, only: [from: 2, last: 1]
+
   alias PaperTrail.Version
   alias PaperTrail.Serializer
 
-  defdelegate get_version(record), to: PaperTrail.VersionQueries
-  defdelegate get_version(model_or_record, id_or_options), to: PaperTrail.VersionQueries
-  defdelegate get_version(model, id, options), to: PaperTrail.VersionQueries
-  defdelegate get_versions(record), to: PaperTrail.VersionQueries
-  defdelegate get_versions(model_or_record, id_or_options), to: PaperTrail.VersionQueries
-  defdelegate get_versions(model, id, options), to: PaperTrail.VersionQueries
-  defdelegate get_current_model(version), to: PaperTrail.VersionQueries
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate make_version_struct(version, model, options), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate serialize(data), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_sequence_id(table_name), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate add_prefix(schema, prefix), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_item_type(data), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_model_id(model), to: Serializer
 
   @doc """
@@ -22,19 +40,8 @@ defmodule PaperTrail do
   @spec insert(changeset :: Ecto.Changeset.t(model), options :: Keyword.t()) ::
           {:ok, %{model: model, version: Version.t()}} | {:error, Ecto.Changeset.t(model) | term}
         when model: struct
-  def insert(
-        changeset,
-        options \\ [
-          origin: nil,
-          meta: nil,
-          originator: nil,
-          prefix: nil,
-          model_key: :model,
-          version_key: :version,
-          ecto_options: []
-        ]
-      ) do
-    PaperTrail.Multi.new()
+  def insert(changeset, options \\ []) do
+    Ecto.Multi.new()
     |> PaperTrail.Multi.insert(changeset, options)
     |> PaperTrail.Multi.commit()
   end
@@ -44,18 +51,7 @@ defmodule PaperTrail do
   """
   @spec insert!(changeset :: Ecto.Changeset.t(model), options :: Keyword.t()) :: model
         when model: struct
-  def insert!(
-        changeset,
-        options \\ [
-          origin: nil,
-          meta: nil,
-          originator: nil,
-          prefix: nil,
-          model_key: :model,
-          version_key: :version,
-          ecto_options: []
-        ]
-      ) do
+  def insert!(changeset, options \\ []) do
     changeset
     |> insert(options)
     |> model_or_error(:insert)
@@ -67,8 +63,8 @@ defmodule PaperTrail do
   @spec update(changeset :: Ecto.Changeset.t(model), options :: Keyword.t()) ::
           {:ok, %{model: model, version: Version.t()}} | {:error, Ecto.Changeset.t(model) | term}
         when model: struct
-  def update(changeset, options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]) do
-    PaperTrail.Multi.new()
+  def update(changeset, options \\ []) do
+    Ecto.Multi.new()
     |> PaperTrail.Multi.update(changeset, options)
     |> PaperTrail.Multi.commit()
   end
@@ -78,7 +74,7 @@ defmodule PaperTrail do
   """
   @spec update!(changeset :: Ecto.Changeset.t(model), options :: Keyword.t()) :: model
         when model: struct
-  def update!(changeset, options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]) do
+  def update!(changeset, options \\ []) do
     changeset
     |> update(options)
     |> model_or_error(:update)
@@ -90,11 +86,8 @@ defmodule PaperTrail do
   @spec delete(model_or_changeset :: model | Ecto.Changeset.t(model), options :: Keyword.t()) ::
           {:ok, %{model: model, version: Version.t()}} | {:error, Ecto.Changeset.t(model) | term}
         when model: struct
-  def delete(
-        model_or_changeset,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
-      ) do
-    PaperTrail.Multi.new()
+  def delete(model_or_changeset, options \\ []) do
+    Ecto.Multi.new()
     |> PaperTrail.Multi.delete(model_or_changeset, options)
     |> PaperTrail.Multi.commit()
   end
@@ -105,13 +98,104 @@ defmodule PaperTrail do
   @spec delete!(model_or_changeset :: model | Ecto.Changeset.t(model), options :: Keyword.t()) ::
           model
         when model: struct
-  def delete!(
-        model_or_changeset,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
-      ) do
+  def delete!(model_or_changeset, options \\ []) do
     model_or_changeset
     |> delete(options)
     |> model_or_error(:delete)
+  end
+
+  @doc """
+  Gets all the versions of a record.
+
+  A list of options is optional, so you can set for example the :prefix of the query,
+  wich allows you to change between different tenants.
+
+  # Usage examples:
+
+      iex> PaperTrail.VersionQueries.get_versions(record)
+      iex> PaperTrail.VersionQueries.get_versions(record, [prefix: "tenant_id"])
+      iex> PaperTrail.VersionQueries.get_versions(ModelName, id)
+      iex> PaperTrail.VersionQueries.get_versions(ModelName, id, [prefix: "tenant_id"])
+  """
+  @spec get_versions(record :: Ecto.Schema.t()) :: [Version.t()]
+  def get_versions(record), do: get_versions(record, [])
+
+  @doc """
+  Gets all the versions of a record given a module and its id
+  """
+  @spec get_versions(model :: module, id :: pos_integer) :: [Version.t()]
+  def get_versions(model, id) when is_atom(model) and is_integer(id),
+    do: get_versions(model, id, [])
+
+  @spec get_versions(record :: Ecto.Schema.t(), options :: Keyword.t()) :: [Version.t()]
+  def get_versions(record, options) when is_map(record) do
+    item_type = record.__struct__ |> Module.split() |> List.last()
+
+    version_query(item_type, Serializer.get_model_id(record), options)
+    |> PaperTrail.RepoClient.repo().all
+  end
+
+  @spec get_versions(model :: module, id :: pos_integer, options :: Keyword.t()) :: [Version.t()]
+  def get_versions(model, id, options) do
+    item_type = model |> Module.split() |> List.last()
+    version_query(item_type, id, options) |> PaperTrail.RepoClient.repo().all
+  end
+
+  @doc """
+  Gets the last version of a record.
+
+  A list of options is optional, so you can set for example the :prefix of the query,
+  wich allows you to change between different tenants.
+
+  # Usage examples:
+
+      iex> PaperTrail.VersionQueries.get_version(record, id)
+      iex> PaperTrail.VersionQueries.get_version(record, [prefix: "tenant_id"])
+      iex> PaperTrail.VersionQueries.get_version(ModelName, id)
+      iex> PaperTrail.VersionQueries.get_version(ModelName, id, [prefix: "tenant_id"])
+  """
+  @spec get_version(record :: Ecto.Schema.t()) :: Version.t() | nil
+  def get_version(record), do: get_version(record, [])
+
+  @spec get_version(model :: module, id :: pos_integer) :: Version.t() | nil
+  def get_version(model, id) when is_atom(model) and is_integer(id),
+    do: get_version(model, id, [])
+
+  @spec get_version(record :: Ecto.Schema.t(), options :: Keyword.t()) :: Version.t() | nil
+  def get_version(record, options) when is_map(record) do
+    item_type = record.__struct__ |> Module.split() |> List.last()
+
+    last(version_query(item_type, Serializer.get_model_id(record), options))
+    |> PaperTrail.RepoClient.repo().one
+  end
+
+  @spec get_version(model :: module, id :: pos_integer, options :: []) :: Version.t() | nil
+  def get_version(model, id, options) do
+    item_type = model |> Module.split() |> List.last()
+    last(version_query(item_type, id, options)) |> PaperTrail.RepoClient.repo().one
+  end
+
+  @doc """
+  Gets the current model record/struct of a version
+  """
+  @spec get_current_model(version :: Version.t()) :: Ecto.Schema.t() | nil
+  def get_current_model(version) do
+    PaperTrail.RepoClient.repo().get(
+      ("Elixir." <> version.item_type) |> String.to_existing_atom(),
+      version.item_id
+    )
+  end
+
+  defp version_query(item_type, id) do
+    from(v in Version, where: v.item_type == ^item_type and v.item_id == ^id)
+  end
+
+  defp version_query(item_type, id, options) do
+    with opts <- Enum.into(options, %{}) do
+      version_query(item_type, id)
+      |> Ecto.Queryable.to_query()
+      |> Map.merge(opts)
+    end
   end
 
   @spec model_or_error(result :: {:ok, %{model: model}}, action :: :insert | :update | :delete) ::

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -1,4 +1,8 @@
 defmodule PaperTrail.Multi do
+  @moduledoc false
+  # TODO: Will be documented again as soon as the insert / update / delete
+  # functions are overhauled
+
   import Ecto.Changeset
 
   alias PaperTrail
@@ -6,35 +10,82 @@ defmodule PaperTrail.Multi do
   alias PaperTrail.RepoClient
   alias PaperTrail.Serializer
 
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.new/0"
   defdelegate new(), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.append/2"
   defdelegate append(lhs, rhs), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.error/3"
   defdelegate error(multi, name, value), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.merge/2"
   defdelegate merge(multi, merge), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.merge/4"
   defdelegate merge(multi, mod, fun, args), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.prepend/2"
   defdelegate prepend(lhs, rhs), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.run/3"
   defdelegate run(multi, name, run), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.run/5"
   defdelegate run(multi, name, mod, fun, args), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Use Ecto.Multi.to_list/1"
   defdelegate to_list(multi), to: Ecto.Multi
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate make_version_struct(version, model, options), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate serialize(data), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_sequence_id(table_name), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate add_prefix(schema, prefix), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_item_type(data), to: Serializer
+
+  # TODO: Remove Function with next major release
+  @doc false
+  @deprecated "Internal API"
   defdelegate get_model_id(model), to: Serializer
 
-  def insert(
-        %Ecto.Multi{} = multi,
-        changeset,
-        options \\ [
-          origin: nil,
-          meta: nil,
-          originator: nil,
-          prefix: nil,
-          model_key: :model,
-          version_key: :version,
-          ecto_options: []
-        ]
-      ) do
+  def insert(%Ecto.Multi{} = multi, changeset, options \\ []) do
     model_key = options[:model_key] || :model
     version_key = options[:version_key] || :version
     ecto_options = options[:ecto_options] || []
@@ -83,11 +134,7 @@ defmodule PaperTrail.Multi do
     end
   end
 
-  def update(
-        %Ecto.Multi{} = multi,
-        changeset,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
-      ) do
+  def update(%Ecto.Multi{} = multi, changeset, options \\ []) do
     case RepoClient.strict_mode() do
       true ->
         multi
@@ -126,11 +173,7 @@ defmodule PaperTrail.Multi do
     end
   end
 
-  def delete(
-        %Ecto.Multi{} = multi,
-        struct,
-        options \\ [origin: nil, meta: nil, originator: nil, prefix: nil]
-      ) do
+  def delete(%Ecto.Multi{} = multi, struct, options \\ []) do
     multi
     |> Ecto.Multi.delete(:model, struct, options)
     |> Ecto.Multi.run(:version, fn repo, %{} ->

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -1,16 +1,16 @@
 defmodule PaperTrail.Multi do
-  @moduledoc false
-  # TODO: Will be documented again as soon as the insert / update / delete
-  # functions are overhauled
-
   import Ecto.Changeset
+
+  require Logger
 
   alias PaperTrail
   alias PaperTrail.Version
   alias PaperTrail.RepoClient
   alias PaperTrail.Serializer
 
-  # TODO: Remove Function with next major release
+  @initial_version {:internal, __MODULE__, :initial_version}
+
+  # TODO: Remove in 1.0
   @doc false
   @deprecated "Use Ecto.Multi.new/0"
   defdelegate new(), to: Ecto.Multi
@@ -85,15 +85,44 @@ defmodule PaperTrail.Multi do
   @deprecated "Internal API"
   defdelegate get_model_id(model), to: Serializer
 
-  def insert(%Ecto.Multi{} = multi, changeset, options \\ []) do
-    model_key = options[:model_key] || :model
-    version_key = options[:version_key] || :version
+  @spec insert(
+          multi :: Ecto.Multi.t(),
+          name :: Ecto.Multi.name(),
+          changeset :: Ecto.Changeset.t(),
+          options :: Keyword.t()
+        ) :: Ecto.Multi.t()
+  def insert(%Ecto.Multi{} = multi, name, changeset, options \\ []) do
+    # TODO: Remove in 1.0
+    model_key =
+      if Keyword.has_key?(options, :model_key) do
+        Logger.warn(
+          "Usage of PaperTrail option `model_key` is deprecated, use the `name` argument instead."
+        )
+
+        Keyword.fetch!(options, :model_key)
+      else
+        name
+      end
+
+    # TODO: Remove in 1.0
+    version_key =
+      if Keyword.has_key?(options, :version_key) do
+        Logger.warn(
+          "Usage of PaperTrail option `version_key` is deprecated, use the `name` argument instead."
+        )
+
+        Keyword.fetch!(options, :version_key)
+      else
+        {name, :version}
+      end
+
+    initial_version_key = {name, @initial_version}
     ecto_options = options[:ecto_options] || []
 
     case RepoClient.strict_mode() do
       true ->
         multi
-        |> Ecto.Multi.run(:initial_version, fn repo, %{} ->
+        |> Ecto.Multi.run(initial_version_key, fn repo, %{} ->
           version_id = get_sequence_id("versions") + 1
 
           changeset_data =
@@ -107,21 +136,23 @@ defmodule PaperTrail.Multi do
           initial_version = make_version_struct(%{event: "insert"}, changeset_data, options)
           repo.insert(initial_version)
         end)
-        |> Ecto.Multi.run(model_key, fn repo, %{initial_version: initial_version} ->
-          updated_changeset =
-            changeset
-            |> change(%{
-              first_version_id: initial_version.id,
-              current_version_id: initial_version.id
-            })
+        |> Ecto.Multi.run(model_key, fn
+          repo, %{^initial_version_key => initial_version} ->
+            updated_changeset =
+              changeset
+              |> change(%{
+                first_version_id: initial_version.id,
+                current_version_id: initial_version.id
+              })
 
-          repo.insert(updated_changeset, ecto_options)
+            repo.insert(updated_changeset, ecto_options)
         end)
-        |> Ecto.Multi.run(version_key, fn repo,
-                                          %{initial_version: initial_version, model: model} ->
-          target_version = make_version_struct(%{event: "insert"}, model, options) |> serialize()
+        |> Ecto.Multi.run(version_key, fn
+          repo, %{^initial_version_key => initial_version, ^model_key => model} ->
+            target_version =
+              make_version_struct(%{event: "insert"}, model, options) |> serialize()
 
-          Version.changeset(initial_version, target_version) |> repo.update
+            Version.changeset(initial_version, target_version) |> repo.update
         end)
 
       _ ->
@@ -134,11 +165,19 @@ defmodule PaperTrail.Multi do
     end
   end
 
-  def update(%Ecto.Multi{} = multi, changeset, options \\ []) do
+  @spec update(
+          multi :: Ecto.Multi.t(),
+          name :: Ecto.Multi.name(),
+          changeset :: Ecto.Changeset.t(),
+          options :: Keyword.t()
+        ) :: Ecto.Multi.t()
+  def update(%Ecto.Multi{} = multi, name, changeset, options \\ []) do
+    initial_version_key = {name, @initial_version}
+
     case RepoClient.strict_mode() do
       true ->
         multi
-        |> Ecto.Multi.run(:initial_version, fn repo, %{} ->
+        |> Ecto.Multi.run(initial_version_key, fn repo, %{} ->
           version_data =
             changeset.data
             |> Map.merge(%{
@@ -149,39 +188,48 @@ defmodule PaperTrail.Multi do
           target_version = make_version_struct(%{event: "update"}, target_changeset, options)
           repo.insert(target_version)
         end)
-        |> Ecto.Multi.run(:model, fn repo, %{initial_version: initial_version} ->
+        |> Ecto.Multi.run(name, fn repo, %{^initial_version_key => initial_version} ->
           updated_changeset = changeset |> change(%{current_version_id: initial_version.id})
           repo.update(updated_changeset, Keyword.take(options, [:returning]))
         end)
-        |> Ecto.Multi.run(:version, fn repo, %{initial_version: initial_version} ->
-          new_item_changes =
-            initial_version.item_changes
-            |> Map.merge(%{
-              current_version_id: initial_version.id
-            })
+        |> Ecto.Multi.run({name, :version}, fn
+          repo, %{^initial_version_key => initial_version} ->
+            new_item_changes =
+              initial_version.item_changes
+              |> Map.merge(%{
+                current_version_id: initial_version.id
+              })
 
-          initial_version |> change(%{item_changes: new_item_changes}) |> repo.update
+            initial_version |> change(%{item_changes: new_item_changes}) |> repo.update
         end)
 
       _ ->
         multi
-        |> Ecto.Multi.update(:model, changeset, Keyword.take(options, [:returning]))
-        |> Ecto.Multi.run(:version, fn repo, %{model: _model} ->
+        |> Ecto.Multi.update(name, changeset, Keyword.take(options, [:returning]))
+        |> Ecto.Multi.run({name, :version}, fn repo, %{^name => _model} ->
           version = make_version_struct(%{event: "update"}, changeset, options)
           repo.insert(version)
         end)
     end
   end
 
-  def delete(%Ecto.Multi{} = multi, struct, options \\ []) do
+  @spec delete(
+          multi :: Ecto.Multi.t(),
+          name :: Ecto.Multi.name(),
+          changeset :: Ecto.Changeset.t(),
+          options :: Keyword.t()
+        ) :: Ecto.Multi.t()
+  def delete(%Ecto.Multi{} = multi, name, struct, options \\ []) do
     multi
-    |> Ecto.Multi.delete(:model, struct, options)
-    |> Ecto.Multi.run(:version, fn repo, %{} ->
+    |> Ecto.Multi.delete(name, struct, options)
+    |> Ecto.Multi.run({name, :version}, fn repo, %{} ->
       version = make_version_struct(%{event: "delete"}, struct, options)
       repo.insert(version, options)
     end)
   end
 
+  @doc false
+  @deprecated "Use c:Ecto.Repo.transaction/1"
   def commit(%Ecto.Multi{} = multi) do
     repo = RepoClient.repo()
 
@@ -190,7 +238,7 @@ defmodule PaperTrail.Multi do
     case RepoClient.strict_mode() do
       true ->
         case transaction do
-          {:error, :model, changeset, %{}} ->
+          {:error, _name, changeset, %{}} ->
             filtered_changes =
               Map.drop(changeset.changes, [:current_version_id, :first_version_id])
 
@@ -202,7 +250,7 @@ defmodule PaperTrail.Multi do
 
       _ ->
         case transaction do
-          {:error, :model, changeset, %{}} -> {:error, Map.merge(changeset, %{repo: repo})}
+          {:error, _name, changeset, %{}} -> {:error, Map.merge(changeset, %{repo: repo})}
           _ -> transaction
         end
     end

--- a/lib/paper_trail/repo_client.ex
+++ b/lib/paper_trail/repo_client.ex
@@ -1,4 +1,6 @@
 defmodule PaperTrail.RepoClient do
+  @moduledoc false
+
   @doc """
   Gets the configured repo module or defaults to Repo if none configured
   """

--- a/lib/paper_trail/serializer.ex
+++ b/lib/paper_trail/serializer.ex
@@ -1,7 +1,6 @@
 defmodule PaperTrail.Serializer do
-  @moduledoc """
-  Serialization functions to create a version struct
-  """
+  @moduledoc false
+  # Serialization functions to create a version struct
 
   alias PaperTrail.RepoClient
   alias PaperTrail.Version

--- a/lib/paper_trail/version_queries.ex
+++ b/lib/paper_trail/version_queries.ex
@@ -1,98 +1,32 @@
 defmodule PaperTrail.VersionQueries do
-  import Ecto.Query
-  alias PaperTrail.Version
+  @moduledoc false
+  # TODO: Remove Module with next major release
 
-  @doc """
-  Gets all the versions of a record.
+  @doc false
+  @deprecated "Use PaperTrail.get_version/1"
+  defdelegate get_version(record), to: PaperTrail
 
-  A list of options is optional, so you can set for example the :prefix of the query,
-  wich allows you to change between different tenants.
+  @doc false
+  @deprecated "Use PaperTrail.get_version/2"
+  defdelegate get_version(model_or_record, id_or_options), to: PaperTrail
 
-  # Usage examples:
+  @doc false
+  @deprecated "Use PaperTrail.get_version/3"
+  defdelegate get_version(model, id, options), to: PaperTrail
 
-    iex(1)> PaperTrail.VersionQueries.get_versions(record)
-    iex(1)> PaperTrail.VersionQueries.get_versions(record, [prefix: "tenant_id"])
-    iex(1)> PaperTrail.VersionQueries.get_versions(ModelName, id)
-    iex(1)> PaperTrail.VersionQueries.get_versions(ModelName, id, [prefix: "tenant_id"])
-  """
-  @spec get_versions(record :: Ecto.Schema.t()) :: [Version.t()]
-  def get_versions(record), do: get_versions(record, [])
+  @doc false
+  @deprecated "Use PaperTrail.get_versions/1"
+  defdelegate get_versions(record), to: PaperTrail
 
-  @doc """
-  Gets all the versions of a record given a module and its id
-  """
-  @spec get_versions(model :: module, id :: pos_integer) :: [Version.t()]
-  def get_versions(model, id) when is_atom(model) and is_integer(id),
-    do: get_versions(model, id, [])
+  @doc false
+  @deprecated "Use PaperTrail.get_versions/2"
+  defdelegate get_versions(model_or_record, id_or_options), to: PaperTrail
 
-  @spec get_versions(record :: Ecto.Schema.t(), options :: []) :: [Version.t()]
-  def get_versions(record, options) when is_map(record) do
-    item_type = record.__struct__ |> Module.split() |> List.last()
+  @doc false
+  @deprecated "Use PaperTrail.get_versions/3"
+  defdelegate get_versions(model, id, options), to: PaperTrail
 
-    version_query(item_type, PaperTrail.get_model_id(record), options)
-    |> PaperTrail.RepoClient.repo().all
-  end
-
-  @spec get_versions(model :: module, id :: pos_integer, options :: []) :: [Version.t()]
-  def get_versions(model, id, options) do
-    item_type = model |> Module.split() |> List.last()
-    version_query(item_type, id, options) |> PaperTrail.RepoClient.repo().all
-  end
-
-  @doc """
-  Gets the last version of a record.
-
-  A list of options is optional, so you can set for example the :prefix of the query,
-  wich allows you to change between different tenants.
-
-  # Usage examples:
-
-    iex(1)> PaperTrail.VersionQueries.get_version(record, id)
-    iex(1)> PaperTrail.VersionQueries.get_version(record, [prefix: "tenant_id"])
-    iex(1)> PaperTrail.VersionQueries.get_version(ModelName, id)
-    iex(1)> PaperTrail.VersionQueries.get_version(ModelName, id, [prefix: "tenant_id"])
-  """
-  @spec get_version(record :: Ecto.Schema.t()) :: Version.t() | nil
-  def get_version(record), do: get_version(record, [])
-
-  @spec get_version(model :: module, id :: pos_integer) :: Version.t() | nil
-  def get_version(model, id) when is_atom(model) and is_integer(id),
-    do: get_version(model, id, [])
-
-  @spec get_version(record :: Ecto.Schema.t(), options :: []) :: Version.t() | nil
-  def get_version(record, options) when is_map(record) do
-    item_type = record.__struct__ |> Module.split() |> List.last()
-
-    last(version_query(item_type, PaperTrail.get_model_id(record), options))
-    |> PaperTrail.RepoClient.repo().one
-  end
-
-  @spec get_version(model :: module, id :: pos_integer, options :: []) :: Version.t() | nil
-  def get_version(model, id, options) do
-    item_type = model |> Module.split() |> List.last()
-    last(version_query(item_type, id, options)) |> PaperTrail.RepoClient.repo().one
-  end
-
-  @doc """
-  Gets the current model record/struct of a version
-  """
-  @spec get_current_model(version :: Version.t()) :: Ecto.Schema.t() | nil
-  def get_current_model(version) do
-    PaperTrail.RepoClient.repo().get(
-      ("Elixir." <> version.item_type) |> String.to_existing_atom(),
-      version.item_id
-    )
-  end
-
-  defp version_query(item_type, id) do
-    from(v in Version, where: v.item_type == ^item_type and v.item_id == ^id)
-  end
-
-  defp version_query(item_type, id, options) do
-    with opts <- Enum.into(options, %{}) do
-      version_query(item_type, id)
-      |> Ecto.Queryable.to_query()
-      |> Map.merge(opts)
-    end
-  end
+  @doc false
+  @deprecated "Use PaperTrail.get_current_model/1"
+  defdelegate get_current_model(version), to: PaperTrail
 end

--- a/test/paper_trail/bang_functions_simple_mode_test.exs
+++ b/test/paper_trail/bang_functions_simple_mode_test.exs
@@ -1092,11 +1092,11 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
     |> repo().insert!
   end
 
-  defp create_company_with_version(params \\ @create_company_params, options \\ nil) do
+  defp create_company_with_version(params \\ @create_company_params, options \\ []) do
     Company.changeset(%Company{}, params) |> PaperTrail.insert!(options)
   end
 
-  defp create_company_with_version_multi(params \\ @create_company_params, options \\ nil) do
+  defp create_company_with_version_multi(params \\ @create_company_params, options \\ []) do
     opts_with_prefix = Keyword.put(options || [], :prefix, MultiTenant.tenant())
 
     Company.changeset(%Company{}, params)
@@ -1111,7 +1111,7 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
   defp update_company_with_version_multi(
          company,
          params \\ @update_company_params,
-         options \\ nil
+         options \\ []
        ) do
     opts_with_prefix = Keyword.put(options || [], :prefix, MultiTenant.tenant())
 

--- a/test/paper_trail/bang_functions_simple_mode_test.exs
+++ b/test/paper_trail/bang_functions_simple_mode_test.exs
@@ -20,8 +20,6 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
   defdelegate repo, to: RepoClient
   defdelegate serialize(data), to: Serializer
 
-  doctest PaperTrail
-
   setup_all do
     Application.put_env(:paper_trail, :strict_mode, false)
     Application.put_env(:paper_trail, :repo, PaperTrail.Repo)

--- a/test/paper_trail/bang_functions_strict_mode_test.exs
+++ b/test/paper_trail/bang_functions_strict_mode_test.exs
@@ -20,8 +20,6 @@ defmodule PaperTrailTest.StrictModeBangFunctions do
   defdelegate repo, to: RepoClient
   defdelegate serialize(data), to: Serializer
 
-  doctest PaperTrail
-
   setup_all do
     Application.put_env(:paper_trail, :strict_mode, true)
     Application.put_env(:paper_trail, :repo, PaperTrail.Repo)

--- a/test/paper_trail/bang_functions_strict_mode_test.exs
+++ b/test/paper_trail/bang_functions_strict_mode_test.exs
@@ -992,11 +992,11 @@ defmodule PaperTrailTest.StrictModeBangFunctions do
     |> repo().insert!
   end
 
-  defp create_company_with_version(params \\ @create_company_params, options \\ nil) do
+  defp create_company_with_version(params \\ @create_company_params, options \\ []) do
     Company.changeset(%Company{}, params) |> PaperTrail.insert!(options)
   end
 
-  defp create_company_with_version_multi(params \\ @create_company_params, options \\ nil) do
+  defp create_company_with_version_multi(params \\ @create_company_params, options \\ []) do
     opts_with_prefix = Keyword.put(options || [], :prefix, MultiTenant.tenant())
 
     Company.changeset(%Company{}, params)

--- a/test/paper_trail/base_test.exs
+++ b/test/paper_trail/base_test.exs
@@ -24,7 +24,7 @@ defmodule PaperTrailTest do
 
   defdelegate serialize(data), to: Serializer
 
-  doctest PaperTrail
+  doctest PaperTrail, except: [get_version: 1, get_versions: 1]
 
   setup_all do
     Application.put_env(:paper_trail, :strict_mode, false)
@@ -591,7 +591,7 @@ defmodule PaperTrailTest do
       })
       |> PaperTrail.insert(origin: "admin")
 
-    assert {:ok, insert_person_result} =
+    assert {:ok, _insert_person_result} =
              Person.changeset(insert_person_result[:model], %{
                singular: nil
              })

--- a/test/paper_trail/strict_mode_test.exs
+++ b/test/paper_trail/strict_mode_test.exs
@@ -19,8 +19,6 @@ defmodule PaperTrailStrictModeTest do
 
   defdelegate serialize(data), to: Serializer
 
-  doctest PaperTrail
-
   setup_all do
     Application.put_env(:paper_trail, :strict_mode, true)
     Application.put_env(:paper_trail, :repo, PaperTrail.Repo)

--- a/test/version/version_queries_test.exs
+++ b/test/version/version_queries_test.exs
@@ -14,6 +14,7 @@ defmodule PaperTrailTest.VersionQueries do
   setup_all do
     Application.put_env(:paper_trail, :repo, PaperTrail.Repo)
     Application.put_env(:paper_trail, :originator_type, :integer)
+    Application.put_env(:paper_trail, :strict_mode, false)
     Code.eval_file("lib/version.ex")
     MultiTenant.setup_tenant(repo())
     reset_all_data()


### PR DESCRIPTION
Based on #131, merge that PR first.

Really exposes Multi implementation so that multiple resources can be persisted at once.

Closes #128 

## Deprecations / Reasons

* `PaperTrail.Multi.insert` Option `model_key` - Since the function now takes a `name` (aligned with `Ecto.Multi`), the option is no longer needed.
* `PaperTrail.Multi.insert` Option `version_key` - Since the function now takes a `name` (aligned with `Ecto.Multi`), the option is no longer needed.