### PR TITLE
fix dialyzer warnings

### DIFF
--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -114,7 +114,10 @@ defmodule PaperTrail do
     |> model_or_error(:delete)
   end
 
-  @spec model_or_error(result :: {:ok, %{model: model}}, action :: :insert | :update | :delete) ::
+  @spec model_or_error(
+          result :: {:ok, %{required(:model) => model, optional(any()) => any()}},
+          action :: :insert | :update | :delete
+        ) ::
           model
         when model: struct()
   defp model_or_error({:ok, %{model: model}}, _action) do

--- a/lib/version.ex
+++ b/lib/version.ex
@@ -41,7 +41,7 @@ defmodule PaperTrail.Version do
     )
   end
 
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, [:item_type, :item_id, :item_changes, :origin, :originator_id, :meta])
     |> validate_required([:event, :item_type, :item_id, :item_changes])


### PR DESCRIPTION
I use Dialyzer (via [dialyxir](https://hexdocs.pm/dialyxir/readme.html)) for increased static type safety in most projects I work on, and there are a couple Dialyzer warnings bubbling up from `paper_trail` (full output below). Most stem from the `@spec` for `PaperTrail.model_or_error/2`.

The updated spec for `model_or_error/2` indicates that other keys are allowed in the `{:ok, %{model: model}}` case. I changed the default value of `params` in `PaperTrail.Version.changeset/2`, since `:empty` will cause a raise.

Here's the full warning output:

```
lib/paper_trail.ex:47:no_return
Function insert!/1 has no local return.
________________________________________________________________________________
lib/paper_trail.ex:47:no_return
Function insert!/2 has no local return.
________________________________________________________________________________
lib/paper_trail.ex:61:call
The function call will not succeed.

PaperTrail.model_or_error(
  {:error, _}
  | {:ok,
     %{
       :model => struct(),
       :version => %PaperTrail.Version{
         :__meta__ => _,
         :event => _,
         :id => _,
         :inserted_at => _,
         :item_changes => _,
         :item_id => _,
         :item_type => _,
         :meta => _,
         :origin => _,
         :originator_id => _
       }
     }},
  :insert
)

will never return since the success typing is:
({:ok, %{:model => map(), :version => map()}}, :delete | :insert | :update) :: map()

and the contract is
Contract head:
(result :: {:ok, %{:model => :model}}, action :: :insert | :update | :delete) :: model
when model: :elixir.struct()

Contract head:
(result :: {:error, reason :: term()}, action :: :insert | :update | :delete) ::
  no_return()

________________________________________________________________________________
lib/paper_trail.ex:81:no_return
Function update!/1 has no local return.
________________________________________________________________________________
lib/paper_trail.ex:81:no_return
Function update!/2 has no local return.
________________________________________________________________________________
lib/paper_trail.ex:84:call
The function call will not succeed.

PaperTrail.model_or_error(
  {:error, _}
  | {:ok,
     %{
       :model => struct(),
       :version => %PaperTrail.Version{
         :__meta__ => _,
         :event => _,
         :id => _,
         :inserted_at => _,
         :item_changes => _,
         :item_id => _,
         :item_type => _,
         :meta => _,
         :origin => _,
         :originator_id => _
       }
     }},
  :update
)

will never return since the success typing is:
({:ok, %{:model => map(), :version => map()}}, :delete | :insert | :update) :: map()

and the contract is
Contract head:
(result :: {:ok, %{:model => :model}}, action :: :insert | :update | :delete) :: model
when model: :elixir.struct()

Contract head:
(result :: {:error, reason :: term()}, action :: :insert | :update | :delete) ::
  no_return()

________________________________________________________________________________
lib/paper_trail.ex:108:no_return
Function delete!/1 has no local return.
________________________________________________________________________________
lib/paper_trail.ex:108:no_return
Function delete!/2 has no local return.
________________________________________________________________________________
lib/paper_trail.ex:114:call
The function call will not succeed.

PaperTrail.model_or_error(
  {:error, _}
  | {:ok,
     %{
       :model => struct(),
       :version => %PaperTrail.Version{
         :__meta__ => _,
         :event => _,
         :id => _,
         :inserted_at => _,
         :item_changes => _,
         :item_id => _,
         :item_type => _,
         :meta => _,
         :origin => _,
         :originator_id => _
       }
     }},
  :delete
)

will never return since the success typing is:
({:ok, %{:model => map(), :version => map()}}, :delete | :insert | :update) :: map()

and the contract is
Contract head:
(result :: {:ok, %{:model => :model}}, action :: :insert | :update | :delete) :: model
when model: :elixir.struct()

Contract head:
(result :: {:error, reason :: term()}, action :: :insert | :update | :delete) ::
  no_return()

________________________________________________________________________________
lib/paper_trail.ex:117:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
PaperTrail.model_or_error/2

Success typing:
@spec model_or_error({:ok, %{:model => map(), :version => map()}}, :delete | :insert | :update) :: map()

________________________________________________________________________________
lib/version.ex:44:no_return
Function changeset/1 has no local return.
________________________________________________________________________________
lib/version.ex:44:call
The function call will not succeed.

PaperTrail.Version.changeset(_ :: any(), :empty)

will never return since the 2nd arguments differ
from the success typing arguments:

(
  {map(), map()}
  | %{:__struct__ => atom() | %{:__changeset__ => map(), _ => _}, atom() => _},
  :invalid | %{:__struct__ => none(), (atom() | binary()) => _}
)

________________________________________________________________________________
```