### PR TITLE
avoid compile-time dependency with Application.get_env at macro

### DIFF
--- a/lib/paper_trail/repo_client.ex
+++ b/lib/paper_trail/repo_client.ex
@@ -2,7 +2,14 @@ defmodule PaperTrail.RepoClient do
   @doc """
   Gets the configured repo module or defaults to Repo if none configured
   """
-  def repo, do: Application.get_env(:paper_trail, :repo, Repo)
-  def originator, do: Application.get_env(:paper_trail, :originator, nil)
-  def strict_mode, do: Application.get_env(:paper_trail, :strict_mode, false)
+  def repo, do: env(:repo, Repo)
+  def originator, do: env(:originator, nil)
+  def strict_mode, do: env(:strict_mode, false)
+  def item_type, do: env(:item_type, :integer)
+  def originator_type, do: env(:originator_type, :integer)
+  def originator_relationship_opts, do: env(:originator_relationship_options, [])
+  def timestamps_type, do: env(:timestamps_type, :utc_datetime)
+  def origin_read_after_writes(), do: env(:origin_read_after_writes, true)
+
+  defp env(k, default), do: Application.get_env(:paper_trail, k, default)
 end

--- a/lib/version.ex
+++ b/lib/version.ex
@@ -6,42 +6,44 @@ defmodule PaperTrail.Version do
 
   @type t :: %__MODULE__{}
 
-  # @setter PaperTrail.RepoClient.originator()
+  alias PaperTrail.RepoClient
+
+  # @setter RepoClient.originator()
   # @item_type Application.get_env(:paper_trail, :item_type, :integer)
   # @originator_type Application.get_env(:paper_trail, :originator_type, :integer)
 
   schema "versions" do
     field(:event, :string)
     field(:item_type, :string)
-    field(:item_id, Application.get_env(:paper_trail, :item_type, :integer))
+    field(:item_id, RepoClient.item_type())
     field(:item_changes, :map)
-    field(:originator_id, Application.get_env(:paper_trail, :originator_type, :integer))
+    field(:originator_id, RepoClient.originator_type())
 
     field(:origin, :string,
-      read_after_writes: Application.get_env(:paper_trail, :origin_read_after_writes, true)
+      read_after_writes:  RepoClient.origin_read_after_writes()
     )
 
     field(:meta, :map)
 
-    if PaperTrail.RepoClient.originator() do
+    if RepoClient.originator() do
       belongs_to(
-        PaperTrail.RepoClient.originator()[:name],
-        PaperTrail.RepoClient.originator()[:model],
-        Keyword.merge(Application.get_env(:paper_trail, :originator_relationship_options, []),
+        RepoClient.originator()[:name],
+        RepoClient.originator()[:model],
+        Keyword.merge(RepoClient.originator_relationship_opts(),
           define_field: false,
           foreign_key: :originator_id,
-          type: Application.get_env(:paper_trail, :originator_type, :integer)
+          type: RepoClient.originator_type()
         )
       )
     end
 
     timestamps(
       updated_at: false,
-      type: Application.get_env(:paper_trail, :timestamps_type, :utc_datetime)
+      type: RepoClient.timestamps_type()
     )
   end
 
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, [:item_type, :item_id, :item_changes, :origin, :originator_id, :meta])
     |> validate_required([:event, :item_type, :item_id, :item_changes])
@@ -51,14 +53,14 @@ defmodule PaperTrail.Version do
   Returns the count of all version records in the database
   """
   def count do
-    from(version in __MODULE__, select: count(version.id)) |> PaperTrail.RepoClient.repo().one()
+    from(version in __MODULE__, select: count(version.id)) |> RepoClient.repo().one()
   end
 
   def count(options) do
     from(version in __MODULE__, select: count(version.id))
     |> Ecto.Queryable.to_query()
     |> Map.put(:prefix, options[:prefix])
-    |> PaperTrail.RepoClient.repo().one
+    |> RepoClient.repo().one
   end
 
   @doc """
@@ -66,14 +68,14 @@ defmodule PaperTrail.Version do
   """
   def first do
     from(record in __MODULE__, limit: 1, order_by: [asc: :inserted_at])
-    |> PaperTrail.RepoClient.repo().one
+    |> RepoClient.repo().one
   end
 
   def first(options) do
     from(record in __MODULE__, limit: 1, order_by: [asc: :inserted_at])
     |> Ecto.Queryable.to_query()
     |> Map.put(:prefix, options[:prefix])
-    |> PaperTrail.RepoClient.repo().one
+    |> RepoClient.repo().one
   end
 
   @doc """
@@ -81,13 +83,13 @@ defmodule PaperTrail.Version do
   """
   def last do
     from(record in __MODULE__, limit: 1, order_by: [desc: :inserted_at])
-    |> PaperTrail.RepoClient.repo().one
+    |> RepoClient.repo().one
   end
 
   def last(options) do
     from(record in __MODULE__, limit: 1, order_by: [desc: :inserted_at])
     |> Ecto.Queryable.to_query()
     |> Map.put(:prefix, options[:prefix])
-    |> PaperTrail.RepoClient.repo().one
+    |> RepoClient.repo().one
   end
 end


### PR DESCRIPTION
moved calls Application.get_env from macro to functions at RepoClient to avoid compile-time dependency and re-compiling it each time for deploying.