### PR TITLE
Fix scenario when originator_ref is a binary

### DIFF
--- a/lib/paper_trail/serializer.ex
+++ b/lib/paper_trail/serializer.ex
@@ -27,6 +27,7 @@ defmodule PaperTrail.Serializer do
         case originator_ref do
           nil -> nil
           %{id: id} -> id
+          id when is_binary(id) -> id
           model when is_struct(model) -> get_model_id(originator_ref)
         end,
       origin: options[:origin],
@@ -48,6 +49,7 @@ defmodule PaperTrail.Serializer do
         case originator_ref do
           nil -> nil
           %{id: id} -> id
+          id when is_binary(id) -> id
           model when is_struct(model) -> get_model_id(originator_ref)
         end,
       origin: options[:origin],
@@ -69,6 +71,7 @@ defmodule PaperTrail.Serializer do
         case originator_ref do
           nil -> nil
           %{id: id} -> id
+          id when is_binary(id) -> id
           model when is_struct(model) -> get_model_id(originator_ref)
         end,
       origin: options[:origin],


### PR DESCRIPTION
Hi @izelnakri 👋

I've got what looks like a bug building versions when inserting an ecto schema.

I think it's because in this scenario the originator is not a foreign key reference, but rather just a string with an identifier.

Adding binary as a clause in the originator_ref seems to do the trick, I don't get the bug anymore. What do you think?

Thanks!

```elixir
     PaperTrail.insert(struct, opts)
     ** (CaseClauseError) no case clause matching: "613247627849051"
     stacktrace:
       (paper_trail 1.0.0) lib/paper_trail/serializer.ex:27: PaperTrail.Serializer.make_version_struct/3
       (paper_trail 1.0.0) lib/paper_trail/multi.ex:83: anonymous fn/4 in PaperTrail.Multi.insert/3
       (ecto 3.10.3) lib/ecto/multi.ex:844: Ecto.Multi.apply_operation/5
       (elixir 1.15.5) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto 3.10.3) lib/ecto/multi.ex:818: anonymous fn/5 in Ecto.Multi.apply_operations/5
       (ecto_sql 3.10.2) lib/ecto/adapters/sql.ex:1352: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
       (db_connection 2.4.3) lib/db_connection.ex:1611: DBConnection.run_transaction/4
       (ecto 3.10.3) lib/ecto/repo/transaction.ex:18: Ecto.Repo.Transaction.transaction/4
       (paper_trail 1.0.0) lib/paper_trail/multi.ex:168: PaperTrail.Multi.commit/1
```