### PR TITLE
Allow custom ecto schema @primary_key

### DIFF
--- a/lib/version.ex
+++ b/lib/version.ex
@@ -4,13 +4,13 @@ defmodule PaperTrail.Version do
   import Ecto.Changeset
   import Ecto.Query
 
-  @type t :: %__MODULE__{}
-
   alias PaperTrail.RepoClient
 
-  # @setter RepoClient.originator()
-  # @item_type Application.get_env(:paper_trail, :item_type, :integer)
-  # @originator_type Application.get_env(:paper_trail, :originator_type, :integer)
+  @type t :: %__MODULE__{}
+
+  if custom_primary_key = Application.compile_env(:paper_trail, :version_primary_key) do
+    @primary_key custom_primary_key
+  end
 
   schema "versions" do
     field(:event, :string)


### PR DESCRIPTION
Paper trail fails to create a new version when the application has `UUID` as migration primary key type:

```elixir
config :xyz, XYZ.Repo, migration_primary_key: [type: :binary_id]
```

```elixir
 ** (Postgrex.Error) ERROR 23502 (not_null_violation) null value in column "id" of relation "versions" violates not-null constraint
     
         table: versions
         column: id
     
     Failing row contains (null, insert, XYZ, 9a955fe1-74db-4038-aaa5-d3a6390036cf, {"id": "9a955fe1-74db-4038-aaa5-d3a6390036cf", "etc": null, "..., null, xyz, {}, 2023-09-07 09:23:50).
```

With this PR, we can store versions with autogenerated UUIDs as ids:

```elixir
config :paper_trail,
  repo: XYZ.Repo,
  version_primary_key: {:id, Ecto.UUID, autogenerate: true}
```

```elixir
version #=> %PaperTrail.Version{
  __meta__: #Ecto.Schema.Metadata<:loaded, "versions">,
  id: "ab1bfacf-e2f7-4d7d-b1ba-fa8dbfefeace",
  event: "update",
  item_type: ...
```

Do you think this approach makes sense?

Cheers!