### PR TITLE
Fix embed serializer to put only changed attrs to `item_changes`

### DIFF
--- a/lib/paper_trail/serializer.ex
+++ b/lib/paper_trail/serializer.ex
@@ -109,11 +109,23 @@ defmodule PaperTrail.Serializer do
   Dumps changes using Ecto fields
   """
   @spec serialize_changes(Ecto.Changeset.t()) :: map()
-  def serialize_changes(%Ecto.Changeset{changes: changes} = changeset) do
+  def serialize_changes(%Ecto.Changeset{data: %schema{}, changes: changes} = changeset) do
+    embed_keys = get_changed_keys(changeset, :embeds)
+
     changeset
     |> serialize_model_changes()
     |> serialize()
     |> Map.take(Map.keys(changes))
+    |> Map.new(fn {key, value} ->
+      if !is_nil(value) && key in embed_keys do
+        case schema.__schema__(:embed, key) do
+          %Ecto.Embedded{cardinality: :one} -> {key, Map.take(value, Map.keys(changes[key].changes))}
+          %Ecto.Embedded{cardinality: :many} -> {key, Enum.map(changes[key], &serialize_changes/1)}
+        end
+      else
+        {key, value}
+      end
+    end)
   end
 
   @doc """
@@ -161,36 +173,27 @@ defmodule PaperTrail.Serializer do
     |> schema.__struct__()
   end
 
-  defp serialize_model_field_changes(%Ecto.Changeset{data: %schema{}, changes: changes}) do
-    change_keys = changes |> Map.keys() |> MapSet.new()
-
-    field_keys =
-      :fields
-      |> schema.__schema__()
-      |> MapSet.new()
-      |> MapSet.intersection(change_keys)
-      |> MapSet.to_list()
-
-    Map.take(changes, field_keys)
+  defp serialize_model_field_changes(%Ecto.Changeset{changes: changes} = changeset) do
+    Map.take(changes, get_changed_keys(changeset, :fields))
   end
 
-  defp serialize_model_embed_changes(%Ecto.Changeset{data: %schema{}, changes: changes}) do
-    change_keys = changes |> Map.keys() |> MapSet.new()
-
-    embed_keys =
-      :embeds
-      |> schema.__schema__()
-      |> MapSet.new()
-      |> MapSet.intersection(change_keys)
-      |> MapSet.to_list()
-
+  defp serialize_model_embed_changes(%Ecto.Changeset{data: %schema{}, changes: changes} = changeset) do
     changes
-    |> Map.take(embed_keys)
+    |> Map.take(get_changed_keys(changeset, :embeds))
     |> Map.new(fn {key, value} ->
       case schema.__schema__(:embed, key) do
         %Ecto.Embedded{cardinality: :one} -> {key, serialize_model_changes(value)}
         %Ecto.Embedded{cardinality: :many} -> {key, Enum.map(value, &serialize_model_changes/1)}
       end
     end)
+  end
+
+  defp get_changed_keys(%Ecto.Changeset{data: %schema{}, changes: changes}, schema_args) do
+    change_keys = changes |> Map.keys() |> MapSet.new()
+
+    schema.__schema__(schema_args)
+    |> MapSet.new()
+    |> MapSet.intersection(change_keys)
+    |> MapSet.to_list()
   end
 end

--- a/test/paper_trail/bang_functions_simple_mode_test.exs
+++ b/test/paper_trail/bang_functions_simple_mode_test.exs
@@ -484,6 +484,13 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              }
            } = version
 
+    assert version.item_changes["plural"] == [
+             %{"name" => "Plural_1"},
+             %{"name" => "Plural_2", "language" => "en"}
+           ]
+
+    assert Map.equal?(version.item_changes["singular"], %{"name" => "Singular"})
+
     assert person == first(Person, :id) |> repo().one
   end
 

--- a/test/paper_trail/bang_functions_simple_mode_test.exs
+++ b/test/paper_trail/bang_functions_simple_mode_test.exs
@@ -454,7 +454,7 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
 
     %Person{
       id: person_id,
-      plural: [%{id: _, name: "Plural"}],
+      plural: [%{id: _, name: "Plural_1"}, %{id: _, name: "Plural_2", language: "en"}],
       singular: %{id: _, name: "Singular"}
     } =
       person =
@@ -467,7 +467,7 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
       })
       |> PaperTrail.insert!()
       |> Person.changeset(%{
-        plural: [%{name: "Plural"}],
+        plural: [%{name: "Plural_1"}, %{name: "Plural_2", language: "en"}],
         singular: %{name: "Singular"}
       })
       |> PaperTrail.update!()
@@ -479,8 +479,8 @@ defmodule PaperTrailTest.SimpleModeBangFunctions do
              item_type: "SimplePerson",
              item_id: ^person_id,
              item_changes: %{
-               "plural" => [%{"id" => _, "name" => "Plural"}],
-               "singular" => %{"id" => _, "name" => "Singular"}
+               "plural" => [%{"name" => "Plural_1"}, %{"name" => "Plural_2", "language" => "en"}],
+               "singular" => %{"name" => "Singular"}
              }
            } = version
 

--- a/test/support/simple_models.ex
+++ b/test/support/simple_models.ex
@@ -138,10 +138,11 @@ defmodule SimpleEmbed do
 
   embedded_schema do
     field(:name, :string)
+    field(:language, :string)
   end
 
   def changeset(model, params \\ %{}) do
     model
-    |> cast(params, [:name])
+    |> cast(params, [:name, :language])
   end
 end


### PR DESCRIPTION
Similar to how changes are tracked in version `item_changes` for top-level entity, the same should apply to embeds.

Issue with the current behavior is that when updating it puts all the attributes available in embedded schema, having new values set only to changed attributes, and others are set to `nil`. Therefore, from a single version record it is impossible to determine whether the value was changed and set to `nil` or not.

Fixed behavior keeps only attributes tracked in changeset as changes, the rest untouched attributes are not put to serialized embed.