### PR TITLE
Use Ecto field names in item changes - not column names 

### DIFF
--- a/lib/paper_trail/serializer.ex
+++ b/lib/paper_trail/serializer.ex
@@ -110,9 +110,10 @@ defmodule PaperTrail.Serializer do
   """
   @spec serialize_changes(Ecto.Changeset.t()) :: map()
   def serialize_changes(%Ecto.Changeset{changes: changes, data: %schema{}} = changeset) do
-     changed_fields = changes
-    |> Map.keys()
-    |> Enum.map(fn key -> {key, schema.__schema__(:field_source, key)} end)
+    changed_fields =
+      changes
+      |> Map.keys()
+      |> Enum.map(fn key -> {key, schema.__schema__(:field_source, key)} end)
 
     columns = Enum.map(changed_fields, fn {_, column} -> column end)
 


### PR DESCRIPTION
Originally only matching db column names would be included, so use of Ecto field source logic was not possible. This changes the item_changes column to reference Ecto field names so all fields are captured. 

Addresses #237